### PR TITLE
Kube version

### DIFF
--- a/scripts/src/chartprreview/verify-report.sh
+++ b/scripts/src/chartprreview/verify-report.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-mandatoryChecks=( "contains-test"
-            "contains-values"
-            "contains-values-schema"
-            "has-minkubeversion"
-            "has-readme"
-            "helm-lint"
-            "images-are-certified"
-            "is-helm-v3"
-            "not-contain-csi-objects"
-            "not-contains-crds" )
+delim=G
+mandatoryChecks=( "${delim}contains-test${delim}"
+            "${delim}contains-values${delim}"
+            "${delim}contains-values-schema${delim}"
+            "${delim}has-kubeversion${delim}"
+            "${delim}has-readme${delim}"
+            "${delim}helm-lint${delim}"
+            "${delim}images-are-certified${delim}"
+            "${delim}is-helm-v3${delim}"
+            "${delim}not-contain-csi-objects${delim}"
+            "${delim}not-contains-crds${delim}" )
 
 
 getDigest() {
@@ -241,15 +242,22 @@ getFails() {
           else
             passed=$((passed+1))
           fi
-          mandatoryChecks=("${mandatoryChecks[@]/$check}")
+
+          if [ $check == "has-minkubeversion" ]; then
+            check="has-kubeversion"
+          fi
+          remove="$delim$check$delim"
+          mandatoryChecks=("${mandatoryChecks[@]/$remove}")
         fi
       fi
     fi
   done < $report
 
   for mandatoryCheck in "${mandatoryChecks[@]}"; do
-    if [ ! -z "$checkA" ]; then
-      fails+=("Missing mandatory check : $mandatoryCheck")
+    if [ ! -z "$mandatoryCheck" ]; then
+      missingcheck="${mandatoryCheck%$delim}"
+      missingcheck="${missingcheck#$delim}"
+      fails+=("Missing mundatory check : $missingcheck")
     fi
   done
 


### PR DESCRIPTION
This fix enables has-kubeVersion and has-minKubeVersion to count as the same test pending the update in chart verifier. The allowance for has-minKubeVersion should be removed before GA.

Also fixed an issue with the mandatory checks. If contains-values was in the report before contains-values-schema, when contains-values was removed from the mandatory checks it both removed  contains-values and changed contains-values-schema to "-schema". To address this I added a delimiter to the start and end of each test name in the mandatory checks so test names become for example, Gcontains-valuesG  and Gcontains-values-schemaG so now removing Gcontains-valuesG  does not affect  Gcontains-values-schemaG.

This needs to merge before I create a PR for the verifier.