### PR TITLE
Document token generation for new CI cluster

### DIFF
--- a/scripts/chart-verifier-cluster-setup.md
+++ b/scripts/chart-verifier-cluster-setup.md
@@ -1,0 +1,33 @@
+# Chart Verifier Cluster Setup
+
+We should create a service account token to set up a new cluster to run the
+chart-verifier for the chart-testing checks.  Later this token can be saved as a
+GitHub secret with the name OPENSHIFT_TOKEN.  The API server address also should
+be stored in another GitHub secret with the name OPENSHIFT_SERVER.
+
+To get token, first log in to cluster with your user token:
+
+```
+oc login --token=<user-token> --server=<api-server-address>
+```
+
+To retrieve the token:
+
+```
+oc apply -f scripts/chart-verifier-cluster-setup.yaml
+SECRET_NAME=`oc get sa chart-verifier-admin -n chart-verifier-infra -o yaml | yq e '.secrets[1].name' -`
+oc get secret $SECRET_NAME -n chart-verifier-infra -o yaml | yq e '.data.token' -
+```
+
+To revoke an existing token, remove the secret:
+
+```
+oc delete secret $SECRET_NAME -n  chart-verifier-infra
+```
+
+After removing the existing secret, the controller recreates it automatically.
+The new token can be retrieved using this command:
+
+```
+oc get secret $SECRET_NAME -n chart-verifier-infra -o yaml | yq e '.data.token' -
+```

--- a/scripts/chart-verifier-cluster-setup.yaml
+++ b/scripts/chart-verifier-cluster-setup.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chart-verifier-infra
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chart-verifier-admin
+  namespace: chart-verifier-infra
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chart-verifier-namespace-creator
+  namespace: chart-verifier-infra
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - 'namespaces'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - 'serviceaccounts'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - 'clusterrolebindings'
+    verbs:
+      - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chart-verifier-namespace-creator-to-admin
+  namespace: chart-verifier-infra
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chart-verifier-namespace-creator
+subjects:
+  - kind: ServiceAccount
+    name: chart-verifier-admin
+    namespace: chart-verifier-infra


### PR DESCRIPTION
This script is going to be used when a new cluster is created.

Partial fullfilment of https://issues.redhat.com/browse/HELM-118