### PR TITLE
Remove false positive error messages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,6 @@ jobs:
         with:
           tag_name: ${{ steps.release-charts.outputs.tag }}
           files: report.yaml
-          fail_on_unmatched_files: true
+          fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -179,8 +179,7 @@ def update_index_and_push(indexdir, repository, branch, category, organization, 
         sys.exit(1)
     out = subprocess.run(["git", "push", f"https://x-access-token:{token}@github.com/{repository}", f"HEAD:refs/heads/{branch}", "-f"], cwd=indexdir, capture_output=True)
     print(out.stdout.decode("utf-8"))
-    err = out.stderr.decode("utf-8")
-    print("error:", err)
+    print(out.stderr.decode("utf-8"))
     if out.returncode:
         print("index.html not updated. Push failed.", "index directory", indexdir, "branch", branch)
         sys.exit(1)


### PR DESCRIPTION
If report.yaml doesn't exist, that's not an error.  Beacuase when user
submit a report directly, that need not be published.

When `git push` command fails, the error message is already captured
using `returncode`.