### PR TITLE
Fix parsing error and make chart-testing mndatory

### DIFF
--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -209,9 +209,9 @@ def check_report_success(directory, report_path, version):
         print("[ERROR] Error extracting annotations from the report:", err)
         sys.exit(1)
 
-    required_annotations = {"helm-chart.openshift.io/lastCertifiedTimestamp",
-                            #TODO: Enable this after OpenShift CI working: "helm-chart.openshift.io/certifiedOpenShiftVersions",
-                            "helm-chart.openshift.io/digest"}
+    required_annotations = {"charts.openshift.io/lastCertifiedTimestamp",
+                            "charts.openshift.io/certifiedOpenShiftVersions",
+                            "charts.openshift.io/digest"}
 
     available_annotations = set(annotations.keys())
 

--- a/scripts/src/chartprreview/verify-report.sh
+++ b/scripts/src/chartprreview/verify-report.sh
@@ -10,8 +10,8 @@ mandatoryChecks=( "${delim}contains-test${delim}"
             "${delim}images-are-certified${delim}"
             "${delim}is-helm-v3${delim}"
             "${delim}not-contain-csi-objects${delim}"
+            "${delim}chart-testing${delim}"
             "${delim}not-contains-crds${delim}" )
-
 
 getDigest() {
 
@@ -157,19 +157,19 @@ getAnnotations() {
       elif [ "$tool" = true ]; then
         if [[ $line == "digest:"* ]]; then
             digest=`echo "$line" | sed 's/digest://' | xargs`
-            annotations+=("\"helm-chart.openshift.io/digest\":\"$digest\"")
+            annotations+=("\"charts.openshift.io/digest\":\"$digest\"")
         elif [[ $line == "lastCertifiedTimestamp:"* ]]; then
             certtime=`echo "$line" | sed 's/lastCertifiedTimestamp://' | xargs`
-            annotations+=("\"helm-chart.openshift.io/lastCertifiedTimestamp\":\"$certtime\"")
-        elif [[ $line == "lastCertifiedTime:"* ]]; then
-            certtime=`echo "$line" | sed 's/lastCertifiedTime://' | xargs`
-            annotations+=("\"helm-chart.openshift.io/lastCertifiedTimestamp\":\"$certtime\"")
+            annotations+=("\"charts.openshift.io/lastCertifiedTimestamp\":\"$certtime\"")
+        elif [[ $line == "certifiedOpenShiftVersions:"* ]]; then
+            osvs=`echo "$line" | sed 's/certifiedOpenShiftVersions://' | xargs`
+            annotations+=("\"charts.openshift.io/certifiedOpenShiftVersions\":\"$osvs\"")
         fi
       elif [ "$chart" = true ]; then
         if [[ $line == "annotations:"* ]]; then
             chartannotations=true
         elif [ "$chartannotations" = true ]; then
-          if [[ $line == "helm-chart.openshift.io/"* ]]; then
+          if [[ $line == "charts.openshift.io/"* ]]; then
              name=`echo $line | cut -d: -f1 | xargs`
              value=`echo "$line" | sed "s#$name:##" | xargs`
              annotations+=("\"$name\":\"$value\"")
@@ -204,27 +204,32 @@ getFails() {
 
   while IFS= read -r line; do
 
+
     if [[ ! -z $line ]]; then
       if [[ $line == "results:"* ]]; then
         results=true
       elif [ "$results" = true ]; then
         if [[ $line == *" - "* ]]; then
             multireason=false
+            nextlinereason=false
             check=""
             type=""
             outcome=""
             reason=""
         fi
         if [[ $line == *"check:"* ]]; then
-           check=`echo $line | cut -d: -f2 | xargs`
+           check=`echo "$line" | cut -d: -f2- | xargs`
         elif [[ $line == *"type:"* ]]; then
-           type=`echo $line | cut -d: -f2 | xargs`
+           type=`echo $line | cut -d: -f2- | xargs`
         elif [[ $line == *"outcome:"* ]]; then
-           outcome=`echo $line | cut -d: -f2 | xargs`
+           outcome=`echo $line | cut -d: -f2- | xargs`
         elif [[ $line == *"reason:"* ]]; then
-           reason=`echo $line | cut -d: -f2 | xargs`
-           if [[ $reason == *'-' ]]; then
+           reason=`echo $line | cut -d: -f2- | xargs`
+           if [[ $reason == *'|-' ]]; then
              multireason=true
+             reason=""
+           elif [[ $reason == *'|' ]]; then
+             nextlinereason=true
              reason=""
            fi
         elif [ "$multireason" = true ]; then
@@ -234,6 +239,9 @@ getFails() {
           else
             outcome="FAIL"
           fi
+        elif [ "$nextlinereason" = true ]; then
+          reason=`echo $line | xargs`
+          nextlinereason=false
         fi
 
         if [ -n "$check" ] && [ -n "$type" ] && [ -n "$outcome" ] && [ -n "$reason" ]; then
@@ -243,9 +251,6 @@ getFails() {
             passed=$((passed+1))
           fi
 
-          if [ $check == "has-minkubeversion" ]; then
-            check="has-kubeversion"
-          fi
           remove="$delim$check$delim"
           mandatoryChecks=("${mandatoryChecks[@]/$remove}")
         fi
@@ -257,7 +262,7 @@ getFails() {
     if [ ! -z "$mandatoryCheck" ]; then
       missingcheck="${mandatoryCheck%$delim}"
       missingcheck="${missingcheck#$delim}"
-      fails+=("Missing mundatory check : $missingcheck")
+      fails+=("Missing mandatory check : $missingcheck")
     fi
   done
 

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -131,9 +131,9 @@ def create_index_from_report(category, report_path):
 
     print("category:", category)
     if category == "partners":
-        annotations["helm-chart.openshift.io/providerType"] = "partner"
+        annotations["charts.openshift.io/providerType"] = "partner"
     else:
-        annotations["helm-chart.openshift.io/providerType"] = category
+        annotations["charts.openshift.io/providerType"] = category
 
     report = yaml.load(open(report_path), Loader=Loader)
     chart_url = report["metadata"]["tool"]['chart-uri']
@@ -165,7 +165,7 @@ def update_index_and_push(indexdir, repository, branch, category, organization, 
         crtentries.append(v)
 
     chart_entry["urls"] = [chart_url]
-    chart_entry["annotations"]["helm-chart.openshift.io/submissionTimestamp"] = now
+    chart_entry["annotations"]["charts.openshift.io/submissionTimestamp"] = now
     crtentries.append(chart_entry)
     data["entries"][entry_name] = crtentries
 
@@ -225,15 +225,15 @@ def update_chart_annotation(category, organization, chart_file_name, chart, repo
 
     print("category:", category)
     if category == "partners":
-        annotations["helm-chart.openshift.io/providerType"] = "partner"
+        annotations["charts.openshift.io/providerType"] = "partner"
     else:
-        annotations["helm-chart.openshift.io/providerType"] = category
+        annotations["charts.openshift.io/providerType"] = category
 
-    if "helm-chart.openshift.io/provider" not in annotations:
+    if "charts.openshift.io/provider" not in annotations:
         data = open(os.path.join("charts", category, organization, chart, "OWNERS")).read()
         out = yaml.load(data, Loader=Loader)
         vendor_name = out["vendor"]["name"]
-        annotations["helm-chart.openshift.io/provider"] = vendor_name
+        annotations["charts.openshift.io/provider"] = vendor_name
 
     out = subprocess.run(["tar", "zxvf", os.path.join(".cr-release-packages", f"{organization}-{chart_file_name}"), "-C", dr], capture_output=True)
     print(out.stdout.decode("utf-8"))


### PR DESCRIPTION
A few changes:
- Fixed problem if reason contains a ":" which was causing missing quotes
- made chart-testing mandatory
- changed the annotation  namespace to  charts.openshift.io
- removed the now redundant code allowing for minkubeverion and lastCertifiedTime 
- included certifiedOpenShiftVersions in annotations