### PR TITLE
A quick workaround for slow server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,7 @@ jobs:
             echo "oc login"
             ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
             ve1/bin/sa-for-chart-testing --create chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }} --token token.txt
+            sleep 10s
             ./oc login --token=$(cat token.txt) --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
           fi
           cd pr-branch


### PR DESCRIPTION
It looks like it's taking few seconds for the Kubernetes resources
to realize.  It's a quick workaround.  We can implement exponential
backoff for checking resources before proceeding.