### PR TITLE
Ensure the SA has access to read clusteroperators

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,6 @@ jobs:
           docker pull quay.io/redhat-certification/chart-verifier:latest
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           if [ "${{steps.sanity_check_pr_content.outputs.report-exists}}" != "true" ]; then
-            echo "oc login"
             ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
             ve1/bin/sa-for-chart-testing --create chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }} --token token.txt
             sleep 10s
@@ -132,6 +131,7 @@ jobs:
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
         run: |
+          ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
           ve1/bin/sa-for-chart-testing --delete chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }}
 
       - name: Save PR artifact


### PR DESCRIPTION
The user running the chart-verifier requires a cluster role that can get values of "clusteroperators". This role is required to retrieve the OpenShift version. So, create the necessary cluster role and cluster role binding.

Ref.
https://github.com/redhat-certification/chart-verifier/issues/111#issuecomment-841622412