### PR TITLE
Update instruction to run tests from the fork

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -439,7 +439,7 @@ Yes, you can do it.
 4. Follow the [documentation to create a service account][sa-cluster-token] and
    corresponding token.  The token should be stored as an [encrypted secret in
    GitHub repository settings][encrypted-secret] with the key as
-   `CLUSTER_TOKEN`.
+   `CLUSTER_TOKEN`.  Follow the same document to create `API_SERVER` secret key.
 5. Create a branch, make the required chart changes and send a pull request to
    your fork's `main` branch.  You should see the results in your fork as
    explained in this document.

--- a/docs/README.md
+++ b/docs/README.md
@@ -433,10 +433,16 @@ messages.
 Yes, you can do it.
 
 1. Ensure the `main` branch in your fork is updated with the latest changes.
-2. Create a GitHub [personal access token][pat] (PAT) and add it as an
-   [encyrpted secret][encyrpted-secret] with name as `BOT_TOKEN`.
-3. Create a branch and make your required changes and send a pull request to
-   your `main` branch.
+2. Ensure there is a `gh-pages` branch in your fork.
+3. You need a publicly accessible OpenShift cluster (See [partner guide to get
+   free access to OCP][partner-ocp]).
+4. Follow the [documentation to create a service account][sa-cluster-token] and
+   corresponding token.  The token should be stored as an [encrypted secret in
+   GitHub repository settings][encrypted-secret] with the key as
+   `CLUSTER_TOKEN`.
+5. Create a branch, make the required chart changes and send a pull request to
+   your fork's `main` branch.  You should see the results in your fork as
+   explained in this document.
 
 ### Can I use any command-line interface to create pull request?
 
@@ -467,3 +473,6 @@ documentation][partner-success-desk].
 [partner-success-desk]: https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/managing-your-account/getting-help/technology-partner-success-desk
 [new-issue]: https://github.com/openshift-helm-charts/repo/issues/new/choose
 [ascii-armor]: https://www.redhat.com/sysadmin/creating-gpg-keypairs
+[partner-ocp]: https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/benefits/software-access
+[sa-cluster-token]: https://github.com/openshift-helm-charts/charts/blob/main/scripts/README.md
+[encrypted-secret]: https://docs.github.com/en/actions/reference/encrypted-secrets

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,12 @@
-## Generating New Token for Cluster
+## Generating New Token for Cluster Access
 
-To generate a new token follow these instructions.
+Access to an OpenShift cluster is necessary to run
+[chart-testing][chart-testing] as part of the [chart-verifier][chart-verifier]
+tool.  This document explains how to generate a service account and
+corresponding token.
 
-Login using your OpenShift token:
+Login using your OpenShift token (change the API server URL for different
+cluster):
 
 ```
 oc login --token=<token-string> --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
@@ -20,14 +24,14 @@ Create new service account, roles, and role bindings:
 oc apply -k scripts/config/overlays/prod/
 ```
 
-There are two secrets associated with the service account, use the note down the
-secret with `token` word in it.  To see the secrets run this command:
+There are two secrets associated with the service account.  Use the secret with
+the `token` word in it.  To see the secrets run this command:
 
 ```
 oc get sa chart-verifier-admin -n prod-chart-verifier-infra -o yaml
 ```
 
-The out should end something like this:
+The output of the above command should end something like this:
 ```
 ...
 secrets:
@@ -41,5 +45,11 @@ Now you can extract the token with this command:
 oc get secret chart-verifier-admin-token-t9sjg -n prod-chart-verifier-infra -o yaml | yq e '.data.token' - | base64 -d -
 ```
 
+(Note: the [yq][yq] is a command-line YAML processor)
+
 You can store the returned value in the GitHub secrets with key as
 `CLUSTER_TOKEN`.
+
+[chart-testing]: https://github.com/helm/chart-testing
+[chart-verifier]: https://github.com/redhat-certification/chart-verifier
+[yq]: https://mikefarah.gitbook.io/yq/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,6 +50,13 @@ oc get secret chart-verifier-admin-token-t9sjg -n prod-chart-verifier-infra -o y
 You can store the returned value in the GitHub secrets with key as
 `CLUSTER_TOKEN`.
 
+Store base64 form of API server URL in the GitHub secrets with key as
+`API_SERVER`.  To create base64 value:
+
+```
+echo -n "https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443" | base64
+```
+
 [chart-testing]: https://github.com/helm/chart-testing
 [chart-verifier]: https://github.com/redhat-certification/chart-verifier
 [yq]: https://mikefarah.gitbook.io/yq/


### PR DESCRIPTION
* Access to an OpenShift cluster is mandatory to run chart-testing
* Personal Access Token (PAT) is not required anymore
* Make instruction to generate token better with more details and links