### PR TITLE
Prevent draft PRs from running workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
   chart-certification:
     name: Chart Certification
     runs-on: ubuntu-20.04
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Draft pull request should not run workflow.  This is only one way
user can send a PR with chart related changes and asks for a review.