### PR TITLE
Fix name in custom resource definition.

### DIFF
--- a/openshift-charts-repo.yaml
+++ b/openshift-charts-repo.yaml
@@ -1,7 +1,8 @@
 apiVersion: helm.openshift.io/v1beta1
 kind: HelmChartRepository
 metadata:
-  name: OpenShift Helm Charts
+  name: openshift-helm-charts
 spec:
+  name: OpenShift Helm Charts
   connectionConfig:
     url: https://charts.openshift.io/


### PR DESCRIPTION
In the Helm CR spec.name can be a human readble string. However,
metadata.name needs to be a dash separated string.