### PR TITLE
Update urllib3

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,4 +4,4 @@ idna==2.10
 PyYAML==5.4.1
 requests==2.25.1
 semver==2.13.0
-urllib3==1.26.4
+urllib3==1.26.5


### PR DESCRIPTION
Changed urllib3 requirement form 1.26.4 to 1.26.5

Only use of the library is when creating a new report

report_content = urllib.parse.unquote(os.environ.get("REPORT_CONTENT"))