### PR TITLE
Remove hard-coded API server value

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,12 +116,13 @@ jobs:
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
         run: |
+          API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
           gpg --version
           docker pull quay.io/redhat-certification/chart-verifier:latest
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           if [ "${{steps.sanity_check_pr_content.outputs.report-exists}}" != "true" ]; then
-            ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
-            ve1/bin/sa-for-chart-testing --create chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }} --token token.txt
+            ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
+            ve1/bin/sa-for-chart-testing --create chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }} --token token.txt --server ${API_SERVER}
           fi
           cd pr-branch
           ../ve1/bin/chart-pr-review --directory=../pr --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
@@ -133,7 +134,8 @@ jobs:
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
         run: |
-          ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
+          API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
+          ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
           ve1/bin/sa-for-chart-testing --delete chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }}
 
       - name: Save PR artifact

--- a/scripts/src/saforcharttesting/saforcharttesting.py
+++ b/scripts/src/saforcharttesting/saforcharttesting.py
@@ -214,10 +214,10 @@ def write_sa_token(namespace, token):
                 with open(token, "w") as fd:
                     fd.write(base64.b64decode(content).decode("utf-8"))
 
-def switch_project_context(namespace, token):
+def switch_project_context(namespace, token, api_server):
     tkn = open(token).read()
     for i in range(7):
-        out = subprocess.run(["./oc", "login", "--token", tkn, "--server", "https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443"], capture_output=True)
+        out = subprocess.run(["./oc", "login", "--token", tkn, "--server", api_server], capture_output=True)
         stdout = out.stdout.decode("utf-8")
         print(stdout)
         out = subprocess.run(["./oc", "project", namespace], capture_output=True)
@@ -243,6 +243,8 @@ def main():
                                         help="service account token for chart testing")
     parser.add_argument("-d", "--delete", dest="delete", type=str, required=False,
                                         help="delete service account and namespace used for chart testing")
+    parser.add_argument("-s", "--server", dest="server", type=str, required=False,
+                                        help="API server URL")
     args = parser.parse_args()
 
     if args.create:
@@ -253,7 +255,7 @@ def main():
         create_clusterrole(args.create)
         create_clusterrolebinding(args.create)
         write_sa_token(args.create, args.token)
-        switch_project_context(args.create, args.token)
+        switch_project_context(args.create, args.token, args.server)
     elif args.delete:
         delete_clusterrolebinding(args.delete)
         delete_clusterrole(args.delete)


### PR DESCRIPTION
The API_SERVER GitHub secret should be created with a base64 encoded
string (Warning: That means that's not really a secret -- the value will
be visible in the log)

To generate base64 encoded string for a URL:

  echo -n "https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443" | base64

Background: This issue came up while updating the documentation about how to run the workflow in the partners fork connecting to their own cluster. API server was hard-coded. This PR moves the API Server URL to GitHub secrets. See this PR: https://github.com/openshift-helm-charts/charts/pull/181 