### PR TITLE
Adding cluster level rules to our cluster role.

### DIFF
--- a/scripts/src/saforcharttesting/saforcharttesting.py
+++ b/scripts/src/saforcharttesting/saforcharttesting.py
@@ -65,6 +65,36 @@ rules:
       - 'clusteroperators'
     verbs:
       - 'get'
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - 'clusterrolebindings'
+      - 'clusterroles'
+    verbs:
+      - 'get'
+      - 'create'
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - 'mutatingwebhookconfigurations'
+    verbs:
+      - 'get'
+      - 'create'
+      - 'list'
+      - 'watch'
+      - 'patch'
+  - apiGroups:
+      - "authentication.k8s.io"
+    resources:
+      - 'tokenreviews'
+    verbs:
+      - 'create'
+  - apiGroups:
+      - "authorization.k8s.io"
+    resources:
+      - 'subjectaccessreviews'
+    verbs:
+      - 'create'
 """
 
 clusterrolebinding_template = """\


### PR DESCRIPTION
These cluster level rules are the minimum needed for the chart-verifier
to be able to validate the hashicorp/vault chart in our current 4.7 repo.