### PR TITLE
Retry PR merge status check

### DIFF
--- a/scripts/src/checkautomerge/checkautomerge.py
+++ b/scripts/src/checkautomerge/checkautomerge.py
@@ -1,5 +1,4 @@
-import re
-import os
+import time
 import sys
 import argparse
 
@@ -8,8 +7,15 @@ import requests
 def ensure_pull_request_not_merged(api_url):
     # api_url https://api.github.com/repos/<organization-name>/<repository-name>/pulls/1
     headers = {'Accept': 'application/vnd.github.v3+json'}
-    r = requests.get(api_url, headers=headers)
-    if not r.json()["merged"]:
+    merged = False
+    for i in range(20):
+        r = requests.get(api_url, headers=headers)
+        if r.json()["merged"]:
+            merged = True
+            break
+        time.sleep(10)
+
+    if not merged:
         print("[ERROR] Pull request not merged")
         sys.exit(1)
 


### PR DESCRIPTION
Sometimes GitHub updates the merge status a bit slow. For example, PR #204 failed as the merge status was negative.
To avoid this scenario, this PR is introducing a retry logic. The maximum wait time is 200 seconds.