### PR TITLE
build.yml: use base64 encoded github secret for CLUSTER_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           docker pull quay.io/redhat-certification/chart-verifier:latest
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           if [ "${{steps.sanity_check_pr_content.outputs.report-exists}}" != "true" ]; then
-            ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
+            ./oc login --token=$( echo -n ${{ secrets.CLUSTER_TOKEN }} | base64 -d) --server=${API_SERVER}
             ve1/bin/sa-for-chart-testing --create chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }} --token token.txt --server ${API_SERVER}
           fi
           cd pr-branch
@@ -135,7 +135,7 @@ jobs:
           KUBECONFIG: /tmp/ci-kubeconfig
         run: |
           API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
-          ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
+          ./oc login --token=$( echo -n ${{ secrets.CLUSTER_TOKEN }} | base64 -d) --server=${API_SERVER}
           ve1/bin/sa-for-chart-testing --delete chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }}
 
       - name: Save PR artifact

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,7 +38,7 @@ secrets:
 Now you can extract the token with this command:
 
 ```
-oc get secret chart-verifier-admin-token-t9sjg -n prod-chart-verifier-infra -o yaml | yq e '.data.token' - | base64 -d -
+oc get secret chart-verifier-admin-token-t9sjg -n prod-chart-verifier-infra -o yaml | yq e '.data.token' -
 ```
 
 You can store the returned value in the GitHub secrets with key as


### PR DESCRIPTION
Consider using base64 encoded github secret for CLUSTER_TOKEN. Because
currently API_SERVER is encoded, it might be better to stay consistent
while using secrets.

Signed-off-by: Allen Bai <abai@redhat.com>