### PR TITLE
make sure sanity check finds a match for report only submission

### DIFF
--- a/scripts/src/sanitycheckpr/sanitycheckpr.py
+++ b/scripts/src/sanitycheckpr/sanitycheckpr.py
@@ -35,10 +35,10 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
             print(msg)
             print(f"::set-output name=sanity-error-message::{msg}")
             sys.exit(1)
-        elif reportpattern.match(filename):
-            print("[INFO] Report found")
-            print("::set-output name=report-exists::true")
         else:
+            if reportpattern.match(filename):
+                print("[INFO] Report found")
+                print("::set-output name=report-exists::true")
             if not match_found:
                 pattern_match = match
                 match_found = True


### PR DESCRIPTION
sanity check logic fails for a report only submission because it fails to find a valid file in the chart directory.  This is because faulty logic meant  it did not register the report as a valid file.

After fixing this logic I re-submitted a report only submission with a timestamp updated and it reran the build process and published the chart.
 


