### PR TITLE
Don't try to create a release for report only submission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,7 @@ jobs:
           cd ${CWD}
 
       - name: Release
+        if: ${{ steps.release-charts.outputs.tag != '' }}
         uses: softprops/action-gh-release@master
         continue-on-error: true
         with:


### PR DESCRIPTION
Add a check for the tag being non blank before running the release. It is not set for report only submission and release will always fail if it is not set.

Tested report only and report with chart. Creates release in latter case.