### PR TITLE
scripts/get-secrets: add a python script for generating GitHub secrets

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,7 @@ To generate a new token follow these instructions.
 Login using your OpenShift token:
 
 ```
-oc login --token=<token-string> --server=https://api.ocpappsvc-osd.zn6c.p1.openshiftapps.com:6443
+oc login --token=<token-string> --server=<api-server-url>
 ```
 
 Delete existing service account, roles, and role bindings:
@@ -43,3 +43,5 @@ oc get secret chart-verifier-admin-token-t9sjg -n prod-chart-verifier-infra -o y
 
 You can store the returned value in the GitHub secrets with key as
 `CLUSTER_TOKEN`.
+
+Alternatively, run `scripts/get-secrets --server <token-string> --server <api-server-url>` to get `CLUSTER_TOKEN` and `API_SERVER`.

--- a/scripts/get-secrets
+++ b/scripts/get-secrets
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+""" Github Actions Secrets Generator
+This script generates CLUSTER_TOKEN and API_SERVER for Github Actions
+Takes two arguments: --token and --server, which aligns with `oc login` command.
+"""
+
+import argparse
+import subprocess
+import sys
+import os
+import re
+import urllib.parse
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--token", dest="token", type=str, required=True,
+                                        help="oc login token")
+    parser.add_argument("-s", "--server", dest="server", type=str, required=True,
+                                        help="OpenShift server URL")
+    args = parser.parse_args()
+
+    out = subprocess.run(["oc", "login", "--insecure-skip-tls-verify", f"--token={args.token}", f"--server={args.server}"], capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error logging in with `oc login`: {err}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(out.stdout.decode("utf-8"), file=sys.stderr)
+
+    cwd = os.path.dirname(__file__)
+    out = subprocess.run(["oc", "delete", "-k", cwd+"/config/overlays/prod/"], capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error deleting existing service account, roles, and role bindings: {err}"
+        print(msg, file=sys.stderr)
+    else:
+        print(out.stdout.decode("utf-8"), file=sys.stderr)
+
+    out = subprocess.run(["oc", "apply", "-k", cwd+"/config/overlays/prod/"], capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error creating new service account, roles, and role bindings: {err}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(out.stdout.decode("utf-8"), file=sys.stderr)
+    
+    out = subprocess.run(["oc", "get", "sa", "chart-verifier-admin", "-n", "prod-chart-verifier-infra", "-o", "yaml"], capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error getting token secret from service account: {err}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(out.stdout.decode("utf-8"), file=sys.stderr)
+
+    pattern = re.compile(r"chart\-verifier\-admin\-token\-[\w]+")
+    secret = pattern.search(out.stdout.decode("utf-8"))
+    if not secret:
+        msg = f"[ERROR] Error finding token secret under service account"
+        print(msg)
+        sys.exit(1)
+
+    out = subprocess.run(["oc", "get", "secret", secret.group(), "-n", "prod-chart-verifier-infra", "-o", "yaml"], capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error getting cluster token secret: {err}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+
+    print(urllib.parse.unquote(out.stdout.decode("utf-8")))
+    out = subprocess.run(["yq", "e", ".data.token", "-"], input=out.stdout, capture_output=True)
+    
+    out = subprocess.run(["base64", "-d", "-"], input=out.stdout, capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error base64 decoding cluster token: {err}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+    cluster_token = out.stdout.decode("utf-8")
+    
+    out = subprocess.run(["echo", "-n", args.server], capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error base64 encoding api server URL: {err}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+
+    out = subprocess.run(["base64", "-w", "0"], input=out.stdout, capture_output=True)
+    err = out.stderr.decode("utf-8")
+    if err.strip():
+        msg = f"[ERROR] Error base64 encoding api server URL: {err}"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+    encoded_api_server = out.stdout.decode("utf-8")
+
+    print(f"CLUSTER_TOKEN: {cluster_token}\n")
+    print(f"API_SERVER: {encoded_api_server}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a python scripts for quick secrets generation for GitHub actions
testing. It strictly follows the instructions under scripts/README.md.

Signed-off-by: Allen Bai <abai@redhat.com>