### PR TITLE
fail sanity check if PR includes more that one chart

### DIFF
--- a/scripts/src/sanitycheckpr/sanitycheckpr.py
+++ b/scripts/src/sanitycheckpr/sanitycheckpr.py
@@ -42,6 +42,12 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
             if not match_found:
                 pattern_match = match
                 match_found = True
+            elif pattern_match.groups() != match.groups():
+                msg = f"[ERROR] PR must only include one chart"
+                print(msg)
+                print(f"::set-output name=sanity-error-message::{msg}")
+                sys.exit(1)
+
 
 
     if match_found:


### PR DESCRIPTION
Added a check to sanity check to make sure only one chart is included in a PR