### PR TITLE
include vendor and semver in file pattern matching

### DIFF
--- a/scripts/src/sanitycheckpr/sanitycheckpr.py
+++ b/scripts/src/sanitycheckpr/sanitycheckpr.py
@@ -12,6 +12,8 @@ except ImportError:
 
 
 ALLOW_CI_CHANGES = "allow/ci-changes"
+SEMVER_MATCH_EXPRESSION = "(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+TYPE_MATCH_EXPRESSION = "(partners|redhat|community)"
 
 def ensure_only_chart_is_modified(api_url, repository, branch):
     # api_url https://api.github.com/repos/<organization-name>/<repository-name>/pulls/1
@@ -23,8 +25,8 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
     files_api_url = f'{api_url}/files'
     headers = {'Accept': 'application/vnd.github.v3+json'}
     r = requests.get(files_api_url, headers=headers)
-    pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/(.+?(?=\/))/.*")
-    reportpattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.]+)/report.yaml")
+    pattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/"+SEMVER_MATCH_EXPRESSION+"/.*")
+    reportpattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/"+SEMVER_MATCH_EXPRESSION+"/report.yaml")
     count = 0
     match_found = False
     for f in r.json():


### PR DESCRIPTION
update the file pattern matching to include the vendorType directory and a valid semantic version  for the version directory.

Wrote  a simple test case to check the new patterns - results:

('start all pattern matcher:', 'partners')
('PASS - matched :', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/src/chart.yaml')
('PASS - matched :', 'charts/partners/test-org1/chart/1.1.0-v3.valid/report.yaml')
('PASS - matched :', 'charts/partners/test-org1/chart/1.1.0-v3.valid/src/chart.yaml')
('PASS - not matched', 'charts/partners/test-org1/chart/OWNERS')
('PASS - matched :', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('PASS - matched :', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - matched :', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/src/.helmignore')
('PASS - not matched', 'charts/partnerspartners/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/partnersa/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('end all pattern matcher:', 'partners')

('start report pattern matcher:', 'partners')
('PASS - not matched', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/src/chart.yaml')
('PASS - matched :', 'charts/partners/test-org1/chart/1.1.0-v3.valid/report.yaml')
('PASS - not matched', 'charts/partners/test-org1/chart/1.1.0-v3.valid/src/chart.yaml')
('PASS - not matched', 'charts/partners/test-org1/chart/OWNERS')
('PASS - matched :', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('PASS - not matched', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/partners/test-org1/ibm-object-storage-plugin/2.1.2/src/.helmignore')
('PASS - not matched', 'charts/partnersa/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/partnerspartners/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('end report pattern matcher:', 'partners')

('start all pattern matcher:', 'redhat')
('PASS - matched :', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/src/chart.yaml')
('PASS - matched :', 'charts/redhat/test-org1/chart/1.1.0-v3.valid/report.yaml')
('PASS - matched :', 'charts/redhat/test-org1/chart/1.1.0-v3.valid/src/chart.yaml')
('PASS - not matched', 'charts/redhat/test-org1/chart/OWNERS')
('PASS - matched :', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('PASS - matched :', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - matched :', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/src/.helmignore')
('PASS - not matched', 'charts/redhatredhat/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/redhata/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('end all pattern matcher:', 'redhat')

('start report pattern matcher:', 'redhat')
('PASS - not matched', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/src/chart.yaml')
('PASS - matched :', 'charts/redhat/test-org1/chart/1.1.0-v3.valid/report.yaml')
('PASS - not matched', 'charts/redhat/test-org1/chart/1.1.0-v3.valid/src/chart.yaml')
('PASS - not matched', 'charts/redhat/test-org1/chart/OWNERS')
('PASS - matched :', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('PASS - not matched', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/redhat/test-org1/ibm-object-storage-plugin/2.1.2/src/.helmignore')
('PASS - not matched', 'charts/redhata/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/redhatredhat/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('end report pattern matcher:', 'redhat')

('start all pattern matcher:', 'community')
('PASS - matched :', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/src/chart.yaml')
('PASS - matched :', 'charts/community/test-org1/chart/1.1.0-v3.valid/report.yaml')
('PASS - matched :', 'charts/community/test-org1/chart/1.1.0-v3.valid/src/chart.yaml')
('PASS - not matched', 'charts/community/test-org1/chart/OWNERS')
('PASS - matched :', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('PASS - matched :', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - matched :', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/src/.helmignore')
('PASS - not matched', 'charts/communitycommunity/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/communitya/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('end all pattern matcher:', 'community')

('start report pattern matcher:', 'community')
('PASS - not matched', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/src/chart.yaml')
('PASS - matched :', 'charts/community/test-org1/chart/1.1.0-v3.valid/report.yaml')
('PASS - not matched', 'charts/community/test-org1/chart/1.1.0-v3.valid/src/chart.yaml')
('PASS - not matched', 'charts/community/test-org1/chart/OWNERS')
('PASS - matched :', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('PASS - not matched', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/community/test-org1/ibm-object-storage-plugin/2.1.2/src/.helmignore')
('PASS - not matched', 'charts/communitya/test-org1/ibm-object-storage-plugin/2.1.2/src/templates/tests/service.yaml')
('PASS - not matched', 'charts/communitycommunity/test-org1/ibm-object-storage-plugin/2.1.2/report.yaml')
('end report pattern matcher:', 'community')
mmulholl-mac:saved martinmulholland$ 
