### PR TITLE
Fixing issue with bad import-values field that brakes helm repo add

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -124,7 +124,7 @@ entries:
     - alias: sch
       condition: ''
       enabled: false
-      importvalues: []
+      import-values: []
       name: ibm-sch
       repository: '@sch'
       tags: []
@@ -185,7 +185,7 @@ entries:
     - alias: sch
       condition: ''
       enabled: false
-      importvalues: []
+      import-values: []
       name: ibm-sch
       repository: '@sch'
       tags: []


### PR DESCRIPTION
This issue brake helm repo add:

```
dperaza@dperaza-mac darwin-amd64 % ./helm version  
version.BuildInfo{Version:"v3.6.2", GitCommit:"ee407bdf364942bcb8e8c665f82e15aa28009b71", GitTreeState:"dirty", GoVersion:"go1.16.3"}
dperaza@dperaza-mac darwin-amd64 % ./helm repo list
NAME              	URL                                                  
bitnami           	https://charts.bitnami.com/bitnami                   
davp              	https://dperaza4dustbit.github.io/helm-chart/        
wildfly           	http://docs.wildfly.org/wildfly-charts/              
gitlab            	https://charts.gitlab.io/                            
redhat-helm-charts	https://redhat-developer.github.io/redhat-helm-charts
dperaza@dperaza-mac darwin-amd64 % ./helm repo add openshift-helm-charts https://charts.openshift.io/
Error: looks like "https://charts.openshift.io/" is not a valid chart repository or cannot be reached: error unmarshaling JSON: while decoding JSON: json: unknown field "importvalues"
```