### PR TITLE
Use report command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
   chart-certification:
     name: Chart Certification
     runs-on: ubuntu-20.04
+    env:
+      VERIFIER_IMAGE: quay.io/redhat-certification/chart-verifier:main
     if: |
       github.event.pull_request.draft == false &&
       (github.event.action != 'labeled' || github.event.label.name == 'force-publish')
@@ -121,7 +123,7 @@ jobs:
         run: |
           API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
           gpg --version
-          docker pull quay.io/redhat-certification/chart-verifier:main
+          docker pull ${{ env.VERIFIER_IMAGE }}
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           if [ "${{steps.sanity_check_pr_content.outputs.report-exists}}" != "true" ]; then
             ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,3 +5,5 @@ PyYAML==5.4.1
 requests==2.25.1
 semver==2.13.0
 urllib3==1.26.5
+docker
+six

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -166,7 +166,7 @@ def match_name_and_version(directory, category, organization, chart, version):
             sys.exit(1)
 
         if os.path.exists("report.yaml"):
-            report_chart = report_info.getReportChart(report_path)
+            report_chart = report_info.getReportChart("report.yaml")
             report_chart_name = report_chart["name"]
             report_chart_version = report_chart["version"]
 
@@ -180,7 +180,7 @@ def match_name_and_version(directory, category, organization, chart, version):
                 write_error_log(directory, msg)
                 sys.exit(1)
     else:
-        report_chart = report_info.getReportChart(report_path)
+        report_chart = report_info.getReportChart("report.yaml")
         report_chart_name = report_chart["name"]
         report_chart_version = report_chart["version"]
 

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -208,7 +208,7 @@ def check_report_success(directory, api_url, report_path, version):
         write_error_log(directory, msg)
         sys.exit(1)
 
-    annotations = report_info.getAnnotations(report_path)
+    annotations = report_info.getReportAnnotations(report_path)
 
     required_annotations = {"charts.openshift.io/lastCertifiedTimestamp",
                             "charts.openshift.io/certifiedOpenShiftVersions",

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -109,7 +109,7 @@ def match_checksum(directory, category, organization, chart, version):
 
     generated_report_path = "report.yaml"
     generated_digests = report_info.getReportDigests(generated_report_path)
-    generated_digest = generated_digests]["chart"]
+    generated_digest = generated_digests["chart"]
 
     if  submitted_digest != generated_digest:
         msg = f"[ERROR] Digest is not matching: {submitted_digest}, {generated_digest}"

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -40,6 +40,7 @@ def get_labels(api_url):
     return r.json()["labels"]
 
 def get_modified_charts(directory, api_url):
+    print("[INFO] Get modified charts.",directory)
     files_api_url = f'{api_url}/files'
     headers = {'Accept': 'application/vnd.github.v3+json'}
     r = requests.get(files_api_url, headers=headers)
@@ -55,6 +56,7 @@ def get_modified_charts(directory, api_url):
     sys.exit(1)
 
 def verify_user(directory, username, category, organization, chart):
+    print("[INFO] Verify user.",username, category, organization, chart)
     owners_path = os.path.join("charts", category, organization, chart, "OWNERS")
     if not os.path.exists(owners_path):
         msg = f"[ERROR] {owners_path} file does not exist."
@@ -69,6 +71,7 @@ def verify_user(directory, username, category, organization, chart):
         sys.exit(1)
 
 def check_owners_file_against_directory_structure(directory,username, category, organization, chart):
+    print("[INFO] Check owners file against directory structure.",category, organization, chart)
     data = open(os.path.join("charts", category, organization, chart, "OWNERS")).read()
     out = yaml.load(data, Loader=Loader)
     vendor_label = out["vendor"]["label"]
@@ -86,6 +89,7 @@ def check_owners_file_against_directory_structure(directory,username, category, 
         sys.exit(1)
 
 def verify_signature(directory, category, organization, chart, version):
+    print("[INFO] Verify signature.",organization, chart, version)
     data = open(os.path.join("charts", category, organization, chart, "OWNERS")).read()
     out = yaml.load(data, Loader=Loader)
     publickey = out.get('publicPgpKey')
@@ -103,6 +107,7 @@ def verify_signature(directory, category, organization, chart, version):
     print("[WARNING]", out.stderr.decode("utf-8"))
 
 def match_checksum(directory, category, organization, chart, version):
+    print("[INFO] Check digests match.",organization, chart, version)
     submitted_report_path = os.path.join("charts", category, organization, chart, version, "report.yaml")
     submitted_digests = report_info.getReportDigests(submitted_report_path)
     submitted_digest = submitted_digests["chart"]
@@ -117,6 +122,7 @@ def match_checksum(directory, category, organization, chart, version):
         sys.exit(1)
 
 def check_url(directory, report_path):
+    print("[INFO] Check chart_url is a valid url.",report_path)
     chart_url = report_info.getReportChartUrl(report_path)
 
     try:
@@ -149,6 +155,7 @@ def check_url(directory, report_path):
         write_error_log(directory, *msgs)
 
 def match_name_and_version(directory, category, organization, chart, version):
+    print("[INFO] Check chart has same name and version as directory structure.",organization, chart, version)
     submitted_report_path = os.path.join("charts", category, organization, chart, version, "report.yaml")
     if os.path.exists(submitted_report_path):
         submitted_report_chart = report_info.getReportChart(submitted_report_path)
@@ -195,6 +202,7 @@ def match_name_and_version(directory, category, organization, chart, version):
             sys.exit(1)
 
 def check_report_success(directory, api_url, report_path, version):
+    print("[INFO] Check report success.",report_path)
     data = open(report_path).read()
     print("[INFO] Full report: ")
     print(data)
@@ -258,6 +266,7 @@ def check_report_success(directory, api_url, report_path, version):
 
 
 def generate_verify_report(directory, category, organization, chart, version):
+    print("[INFO] Generate verify report.",organization,chart,version)
     src = os.path.join(os.getcwd(), "charts", category, organization, chart, version, "src")
     report_path = os.path.join("charts", category, organization, chart, version, "report.yaml")
     src_exists = False

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -167,7 +167,7 @@ def set_package_digest(chart_entry):
         target_digest = hashlib.sha256(response.content).hexdigest()
     
     if target_digest:
-        if not chart_entry["digest"]
+        if not chart_entry["digest"]:
             # Digest was computed but not passed
             chart_entry["digest"] = target_digest
         elif chart_entry["digest"] != target_digest:

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -165,15 +165,19 @@ def set_package_digest(chart_entry):
     if head.status_code == 200:
         response = requests.get(url, allow_redirects=True)
         target_digest = hashlib.sha256(response.content).hexdigest()
+
+    pkg_digest = ""
+    if "digest" in chart_entry:
+        pkg_digest = chart_entry["digest"]
     
     if target_digest:
-        if not chart_entry["digest"]:
+        if not pkg_digest:
             # Digest was computed but not passed
             chart_entry["digest"] = target_digest
-        elif chart_entry["digest"] != target_digest:
+        elif ckg_digest != target_digest:
             # Digest was passed and computed but differ
             raise Exception("Found an integrity issue. SHA256 digest passed does not match SHA256 digest computed.")
-    elif not chart_entry["digest"]:
+    elif not pkg_digest:
         # Digest was not passed and could not be computed
         raise Exception("Was unable to compute SHA256 digest, please ensure chart url points to a chart package.")
 

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -152,7 +152,8 @@ def create_index_from_report(category, report_path):
     chart_entry["annotations"] = chart_entry["annotations"] | annotations
 
     digests = report_info.getReportDigests(report_path)
-    chart_entry["digest"] = digests["digests"]["package"]
+    if "package" in digests:
+        chart_entry["digest"] = digests["package"]
 
     return chart_entry, chart_url
 

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -73,6 +73,7 @@ def generate_report(chart_file_name):
     return report_path
 
 def prepare_chart_source_for_release(category, organization, chart, version):
+    print("[INFO] prepare chart source for release.",category, organization, chart, version)
     path = os.path.join("charts", category, organization, chart, version, "src")
     out = subprocess.run(["helm", "package", path], capture_output=True)
     print(out.stdout.decode("utf-8"))
@@ -86,6 +87,7 @@ def prepare_chart_source_for_release(category, organization, chart, version):
     shutil.copy(f"{chart}-{version}.tgz" , f".cr-release-packages/{new_chart_file_name}")
 
 def prepare_chart_tarball_for_release(category, organization, chart, version):
+    print("[INFO] prepare chart tarball for release.",category, organization, chart, version)
     chart_file_name = f"{chart}-{version}.tgz"
     new_chart_file_name = f"{organization}-{chart}-{version}.tgz"
     path = os.path.join("charts", category, organization, chart, version, chart_file_name)
@@ -97,6 +99,7 @@ def prepare_chart_tarball_for_release(category, organization, chart, version):
     shutil.copy(path, chart_file_name)
 
 def push_chart_release(repository, organization, commit_hash):
+    print("[INFO]push chart release.",repository, organization, commit_hash)
     org, repo = repository.split("/")
     token = os.environ.get("GITHUB_TOKEN")
     print("[INFO] Upload chart using the chart-releaser")
@@ -125,6 +128,7 @@ def create_worktree_for_index(branch):
     return dr
 
 def create_index_from_chart(indexdir, repository, branch, category, organization, chart, version, chart_url):
+    print("[INFO] create index from chart.",category, organization, chart, version, chart_url)
     path = os.path.join("charts", category, organization, chart, version)
     chart_file_name = f"{chart}-{version}.tgz"
     out = subprocess.run(["helm", "show", "chart", os.path.join(".cr-release-packages", chart_file_name)], capture_output=True)
@@ -135,6 +139,7 @@ def create_index_from_chart(indexdir, repository, branch, category, organization
     return crt
 
 def create_index_from_report(category, report_path):
+    print("[INFO] create index from report.",category, report_path)
 
     annotations = report_info.getReportAnnotations(report_path)
 
@@ -163,6 +168,7 @@ def create_index_from_report(category, report_path):
 
 
 def set_package_digest(chart_entry):
+    print("[INFO] set package digests.")
 
     url = chart_entry["urls"][0]
     head = requests.head(url, allow_redirects=True)
@@ -264,6 +270,7 @@ def update_index_and_push(indexdir, repository, branch, category, organization, 
 
 
 def update_chart_annotation(category, organization, chart_file_name, chart, report_path):
+    print("[INFO] Update chart annotation.",category, organization, chart_file_name, chart)
     dr = tempfile.mkdtemp(prefix="annotations-")
 
     annotations = report_info.getReportAnnotations(report_path)

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -149,7 +149,11 @@ def create_index_from_report(category, report_path):
 
     chart_url = report_info.getReportChartUrl(report_path)
     chart_entry = report_info.getReportChart(report_path)
-    chart_entry["annotations"] = chart_entry["annotations"] | annotations
+    if "annotations" in chart_entry:
+        annotations = chart_entry["annotations"] | annotations
+
+    chart_entry["annotations"] = annotations
+
 
     digests = report_info.getReportDigests(report_path)
     if "package" in digests:

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -175,7 +175,7 @@ def set_package_digest(chart_entry):
         if not pkg_digest:
             # Digest was computed but not passed
             chart_entry["digest"] = target_digest
-        elif ckg_digest != target_digest:
+        elif pkg_digest != target_digest:
             # Digest was passed and computed but differ
             raise Exception("Found an integrity issue. SHA256 digest passed does not match SHA256 digest computed.")
     elif not pkg_digest:

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -136,7 +136,7 @@ def create_index_from_chart(indexdir, repository, branch, category, organization
 
 def create_index_from_report(category, report_path):
 
-    annotations = report_info.getAnnotations(report_path)
+    annotations = report_info.getReportAnnotations(report_path)
 
     print("category:", category)
     redhat_to_community = bool(os.environ.get("REDHAT_TO_COMMUNITY"))
@@ -147,8 +147,8 @@ def create_index_from_report(category, report_path):
     else:
         annotations["charts.openshift.io/providerType"] = category
 
-    chart_url = report_info.getChartUrl(report_path)
-    chart_entry = report_info.getChart(report_path)
+    chart_url = report_info.getReportChartUrl(report_path)
+    chart_entry = report_info.getReportChart(report_path)
     chart_entry["annotations"] = chart_entry["annotations"] | annotations
 
     digests = report_info.getReportDigests(report_path)
@@ -257,7 +257,7 @@ def update_index_and_push(indexdir, repository, branch, category, organization, 
 def update_chart_annotation(category, organization, chart_file_name, chart, report_path):
     dr = tempfile.mkdtemp(prefix="annotations-")
 
-    annotations = report_info.getAnnotations(report_path)
+    annotations = report_info.getReportAnnotations(report_path)
 
     print("category:", category)
     redhat_to_community = bool(os.environ.get("REDHAT_TO_COMMUNITY"))

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -1,0 +1,90 @@
+
+import re
+import os
+import sys
+import docker
+import argparse
+import subprocess
+import json
+import yaml
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+REPORT_ANNOTATIONS = "annotations"
+REPORT_RESULTS = "results"
+REPORT_DIGESTS = "digests"
+REPORT_METADATA= "metadata"
+
+def getReport(report_path):
+    try:
+        report = yaml.load(open(report_path), Loader=Loader)
+    except yaml.scanner.ScannerError as err:
+        msg = "[ERROR] YAML error: {0}".format(err)
+        write_error_log(directory, msg)
+        sys.exit(1)
+    except:
+        msg = "[ERROR] Unexpected error:", sys.exc_info()[0]
+        write_error_log(directory, msg)
+        sys.exit(1)
+
+def getReportInfo(report_path,info_type,profile_type,profile_version):
+
+    docker_command = "report " + info_type + " charts/"+os.path.basename(report_path)
+
+    set_values = ""
+    if profile_type:
+        set_values = "profile.vendortype="+profile_type
+    if profile_version:
+        if set_values:
+            set_values = set_values + ","
+        set_values = set_values + "profile.version="+profile_version
+
+    if set_values:
+        docker_command += " --set " + set_values
+
+    client = docker.from_env()
+    output = client.containers.run(os.environ.get("VERIFIER_IMAGE"),docker_command,stdin_open=True,tty=True,stderr=True,volumes={os.path.dirname(report_path): {'bind': '/charts/', 'mode': 'rw'}})
+    report_out = json.loads(output)
+
+    print(f"[INFO] report {info_type} :",report_out)
+
+    if not report_out[info_type]:
+        print(f"Error extracting {info_type} from the report:", r.strip())
+        sys.exit(1)
+
+    if info_type == REPORT_ANNOTATIONS:
+        annotations = {}
+        for report_annotation in report_out[REPORT_ANNOTATIONS]:
+            annotations[report_annotation["name"]] = report_annotation["value"]
+
+        return annotations
+
+    #return json.dumps(report_out[info_type])
+    return report_out[info_type]
+
+
+def getReportAnnotations(report_path):
+    return getReportInfo(report_path,REPORT_ANNOTATIONS,"","")
+
+def getReportResults(report_path,profile_type,profile_version):
+    return getReportInfo(report_path,REPORT_RESULTS,profile_type,profile_version)
+
+def getReportDigests(report_path):
+    return getReportInfo(report_path,REPORT_DIGESTS,"","")
+
+def getReportMetadata(report_path):
+    return getReportInfo(report_path,REPORT_METADATA,"","")
+
+def getReportChartUrl(report_path):
+     report = getReport(report_path)
+     return report["metadata"]["tool"]["chart-uri"]
+
+def getReportChart(report_path):
+     report = getReport(report_path)
+     return report["metadata"]["chart"]
+
+
+
+

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -28,6 +28,7 @@ def getReport(report_path):
         msg = "[ERROR] Unexpected error:", sys.exc_info()[0]
         write_error_log(directory, msg)
         sys.exit(1)
+    return report
 
 def getReportInfo(report_path,info_type,profile_type,profile_version):
 

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -46,8 +46,6 @@ def getReportInfo(report_path,info_type,profile_type,profile_version):
     output = client.containers.run(os.environ.get("VERIFIER_IMAGE"),docker_command,stdin_open=True,tty=True,stderr=True,volumes={report_directory: {'bind': '/charts/', 'mode': 'rw'}})
     report_out = json.loads(output)
 
-    print(f"[INFO] report {info_type} :",report_out)
-
     if not info_type in report_out:
         print(f"Error extracting {info_type} from the report:", r.strip())
         sys.exit(1)
@@ -63,26 +61,35 @@ def getReportInfo(report_path,info_type,profile_type,profile_version):
 
 
 def getReportAnnotations(report_path):
-    return getReportInfo(report_path,REPORT_ANNOTATIONS,"","")
+    annotations = getReportInfo(report_path,REPORT_ANNOTATIONS,"","")
+    print("[INFO] report annotations :",annotations)
+    return annotations
 
 def getReportResults(report_path,profile_type,profile_version):
     results = getReportInfo(report_path,REPORT_RESULTS,profile_type,profile_version)
+    print("[INFO] report results :",results)
     results["failed"] = int(results["failed"])
     results["passed"] = int(results["passed"])
     return results
     
 def getReportDigests(report_path):
-    return getReportInfo(report_path,REPORT_DIGESTS,"","")
+    digests = getReportInfo(report_path,REPORT_DIGESTS,"","")
+    print("[INFO] report digests :",digests)
+    return digests
 
 def getReportMetadata(report_path):
-    return getReportInfo(report_path,REPORT_METADATA,"","")
+    metadata = getReportInfo(report_path,REPORT_METADATA,"","")
+    print("[INFO] report digests :",digests)
+    return metadata
 
 def getReportChartUrl(report_path):
      metadata = getReportInfo(report_path,REPORT_METADATA,"","")
+     print("[INFO] report chart-uri :",metadata["chart-uri"])
      return metadata["chart-uri"]
 
 def getReportChart(report_path):
      metadata = getReportInfo(report_path,REPORT_METADATA,"","")
+     print("[INFO] report chart :",metadata["chart"])
      return metadata["chart"]
 
 

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -19,7 +19,7 @@ def getReport(report_path):
     try:
         report = yaml.load(open(report_path), Loader=Loader)
     except yaml.scanner.ScannerError as err:
-        print("[ERROR] YAML error loading report:",format(err)
+        print("[ERROR] YAML error loading report:",format(err))
         sys.exit(1)
     except:
         print("[ERROR] Unexpected error loading report:", sys.exc_info()[0])

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -46,7 +46,8 @@ def getReportInfo(report_path,info_type,profile_type,profile_version):
         docker_command += " --set " + set_values
 
     client = docker.from_env()
-    output = client.containers.run(os.environ.get("VERIFIER_IMAGE"),docker_command,stdin_open=True,tty=True,stderr=True,volumes={os.path.dirname(report_path): {'bind': '/charts/', 'mode': 'rw'}})
+    report_directory = os.path.dirname(os.path.abspath(report_path))
+    output = client.containers.run(os.environ.get("VERIFIER_IMAGE"),docker_command,stdin_open=True,tty=True,stderr=True,volumes={report_directory: {'bind': '/charts/', 'mode': 'rw'}})
     report_out = json.loads(output)
 
     print(f"[INFO] report {info_type} :",report_out)

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -71,8 +71,11 @@ def getReportAnnotations(report_path):
     return getReportInfo(report_path,REPORT_ANNOTATIONS,"","")
 
 def getReportResults(report_path,profile_type,profile_version):
-    return getReportInfo(report_path,REPORT_RESULTS,profile_type,profile_version)
-
+    results = getReportInfo(report_path,REPORT_RESULTS,profile_type,profile_version)
+    results["failed"] = int(results["failed"])
+    results["passed"] = int(results["passed"])
+    return results
+    
 def getReportDigests(report_path):
     return getReportInfo(report_path,REPORT_DIGESTS,"","")
 

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -15,17 +15,6 @@ REPORT_RESULTS = "results"
 REPORT_DIGESTS = "digests"
 REPORT_METADATA= "metadata"
 
-def getReport(report_path):
-    try:
-        report = yaml.load(open(report_path), Loader=Loader)
-    except yaml.scanner.ScannerError as err:
-        print("[ERROR] YAML error loading report:",format(err))
-        sys.exit(1)
-    except:
-        print("[ERROR] Unexpected error loading report:", sys.exc_info()[0])
-        sys.exit(1)
-    return report
-
 def getReportInfo(report_path,info_type,profile_type,profile_version):
 
     docker_command = "report " + info_type + " charts/"+os.path.basename(report_path)

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -1,10 +1,8 @@
 
-import re
 import os
 import sys
 import docker
-import argparse
-import subprocess
+import logging
 import json
 import yaml
 try:
@@ -21,12 +19,10 @@ def getReport(report_path):
     try:
         report = yaml.load(open(report_path), Loader=Loader)
     except yaml.scanner.ScannerError as err:
-        msg = "[ERROR] YAML error: {0}".format(err)
-        write_error_log(directory, msg)
+        print("[ERROR] YAML error loading report:",format(err)
         sys.exit(1)
     except:
-        msg = "[ERROR] Unexpected error:", sys.exc_info()[0]
-        write_error_log(directory, msg)
+        print("[ERROR] Unexpected error loading report:", sys.exc_info()[0])
         sys.exit(1)
     return report
 
@@ -52,7 +48,7 @@ def getReportInfo(report_path,info_type,profile_type,profile_version):
 
     print(f"[INFO] report {info_type} :",report_out)
 
-    if not report_out[info_type]:
+    if not info_type in report_out:
         print(f"Error extracting {info_type} from the report:", r.strip())
         sys.exit(1)
 
@@ -63,7 +59,6 @@ def getReportInfo(report_path,info_type,profile_type,profile_version):
 
         return annotations
 
-    #return json.dumps(report_out[info_type])
     return report_out[info_type]
 
 

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -83,12 +83,12 @@ def getReportMetadata(report_path):
     return getReportInfo(report_path,REPORT_METADATA,"","")
 
 def getReportChartUrl(report_path):
-     report = getReport(report_path)
-     return report["metadata"]["tool"]["chart-uri"]
+     metadata = getReportInfo(report_path,REPORT_METADATA,"","")
+     return metadata["chart-uri"]
 
 def getReportChart(report_path):
-     report = getReport(report_path)
-     return report["metadata"]["chart"]
+     metadata = getReportInfo(report_path,REPORT_METADATA,"","")
+     return metadata["chart"]
 
 
 


### PR DESCRIPTION
The PR contains:

1. Update to use new chart verifier report command to get from the report
- check results
- chart digests 
- chart-uri 
- chart metadata
- vendor-type and profile version
- annotations
2. Added a global environment varaible for the verifier image so that when the image used is changed it only need to be updated in one place. 
3. Added some INFO message outputs at the start of python functions including interesting input parameter values. 

Tested chart source only, chart tarball only, report only and chart + report.

This addresses:
- https://issues.redhat.com/browse/HELM-198

However because the chart contrnt is now  obtained as JSON instead of yaml it also addresses:
- https://issues.redhat.com/browse/HELM-210