### PR TITLE
workflows: fallback to v0.1.5 for softprops/action-gh-release (#263)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Release
         if: ${{ steps.release-charts.outputs.tag != '' }}
-        uses: softprops/action-gh-release@master
+        uses: softprops/action-gh-release@v0.1.5
         continue-on-error: true
         with:
           tag_name: ${{ steps.release-charts.outputs.tag }}


### PR DESCRIPTION
After newest release of softprops/action-gh-release action, the workflow
failed to start with error:
https://github.com/openshift-helm-charts/charts/pull/261/checks. While
the authors of the action are working on this issue, we should consider
using the previos stable release.

Ref: https://github.com/softprops/action-gh-release/issues/125
Signed-off-by: Allen Bai <abai@redhat.com>