### PR TITLE
Add workflow for CI changes and Chart re-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,21 +17,41 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.x
+      - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
 
+      - name: Set up Python 3.x Part 2
+        run: |
+          # set up python
+          python3 -m venv ve1
+          cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
+          cd scripts && ../ve1/bin/python3 setup.py install && cd ..
+
+      - name: Check for CI changes
+        id: check_ci_changes
+        run: |
+          # check if workflow testing should run.
+          echo "[INFO] check if PR contains only workflow changes and user is authorized"
+          ve1/bin/check-pr-for-ci --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
+
+      - name: Exit if CI tests will run
+        id: exit_if_ci
+        if: steps.check_ci_changes.outputs.run-tests == 'true'
+        run: |
+          # exit: workflow testing will run.
+          echo "The PR is workflow changes only - do not continue."
+          exit
+
       - name: Sanity Check PR Content
         id: sanity_check_pr_content
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         continue-on-error: true
         env:
           GITHUB_REF: ${{ github.ref }}
         run: |
-          python3 -m venv ve1
-          cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
-          cd scripts && ../ve1/bin/python3 setup.py install && cd ..
-          INDEX_BRANCH=$(if [ "${GITHUB_REF}" = "refs/heads/main" ]; then echo "refs/heads/gh-pages"; else echo "${GITHUB_REF}-gh-pages"; fi)
+         INDEX_BRANCH=$(if [ "${GITHUB_REF}" = "refs/heads/main" ]; then echo "refs/heads/gh-pages"; else echo "${GITHUB_REF}-gh-pages"; fi)
           ./ve1/bin/sanity-check-pr --index-branch=${INDEX_BRANCH} --repository=${{ github.repository }} --api-url=${{ github.event.pull_request._links.self.href }}
 
       - uses: actions/github-script@v3
@@ -68,6 +88,7 @@ jobs:
 
       - name: 'Remove label from PR'
         uses: actions/github-script@v3
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,6 +102,7 @@ jobs:
             })
 
       - name: Checkout
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -89,26 +111,28 @@ jobs:
 
       - name: Get Date
         id: get-date
-        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' }}
+        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.check_ci_changes.outputs.run-tests != 'true'}}
         run: |
           echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
 
       - uses: actions/cache@v2
-        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' }}
+        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.check_ci_changes.outputs.run-tests != 'true'}}
         id: cache
         with:
           path: oc
           key: ${{ steps.get-date.outputs.date }}
 
       - name: Install oc
-        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.cache.outputs.cache-hit != 'true' }}
+        id: install-oc
+        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.check_ci_changes.outputs.run-tests != 'true'}}
         run: |
           curl -sLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
           tar zxvf openshift-client-linux.tar.gz oc
+          echo "::set-output name=oc-installed::true"
 
       - name: Get Repository
-        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' }}
+        if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.check_ci_changes.outputs.run-tests != 'true'}}
         id: get-repository
         run: |
           REPO=$(echo ${{ github.repository }} | tr '\/' '-')
@@ -117,6 +141,7 @@ jobs:
 
       - name: 'Verify PR - generate report'
         id: verify_pr
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
           VENDOR_TYPE: ${{ steps.sanity_check_pr_content.outputs.category }}
@@ -135,7 +160,7 @@ jobs:
 
 
       - name: Delete Namespace
-        if: always() && steps.sanity_check_pr_content.outputs.report-exists != 'true'
+        if: steps.install-oc.outputs.oc-installed == 'true'
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
         run: |
@@ -144,19 +169,19 @@ jobs:
           ve1/bin/sa-for-chart-testing --delete chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }}
 
       - name: Save PR artifact
-        if: always()
+        if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
         run: |
           ve1/bin/pr-artifact --directory=./pr --pr-number=${{ github.event.number }} --api-url=${{ github.event.pull_request._links.self.href }}
 
       - name: 'Prepare PR comment'
-        if: always()
+        if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
         env:
           SANITY_ERROR_MESSAGE: ${{ steps.sanity_check_pr_content.outputs.sanity-error-message }}
         run: |
           python3 scripts/prepare_pr_comment.py ${{ steps.sanity_check_pr_content.outcome }} ${{ steps.verify_pr.conclusion }} ${{ github.repository }}
 
       - name: 'Comment on PR'
-        if: always()
+        if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +197,7 @@ jobs:
             });
 
       - name: 'Add label to PR'
-        if: ${{ always() && steps.sanity_check_pr_content.outcome == 'success'}}
+        if: ${{ always() && steps.sanity_check_pr_content.outcome == 'success' && steps.check_ci_changes.outputs.run-tests != 'true' }}
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -206,20 +231,24 @@ jobs:
           MERGE_LABELS: ""
 
       - name: Check for PR merge
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         run: |
           ./ve1/bin/check-auto-merge --api-url=${{ github.event.pull_request._links.self.href }}
 
       - name: Block until there is no running workflow
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         uses: softprops/turnstyle@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Release Charts
+        if: steps.check_ci_changes.outputs.run-tests != 'true'
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,18 @@ on:
     types: [opened, synchronize, reopened, edited, labeled, workflow_dispatch]
   workflow_dispatch:
       inputs:
+        dry-run:
+          description: 'Run tests but do not create issues {true,false}'
+          required: true
+          default: 'true'
+        notify-id:
+          description: 'Issue notification {github id}'
+          required: false
+          default:
         vendor-type:
           description: 'Vendor type {all,partner,redhat,community}'
           required: true
           default: 'all'
-        notify-id:
-          description: 'Issue notification {OWNERS,none,<github id>}'
-          required: true
-          default: 'none'
         software-name:
           description: 'Software Name'
           required: true
@@ -63,6 +67,7 @@ jobs:
         env:
           CLUSTER_TOKEN: ${{ secrets.CLUSTER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: = ${{ github.event.inputs.dry-run }}
           VENDOR_TYPE: = ${{ github.event.inputs.vendor-type }}
           NOTIFY_ID: = ${{ github.event.inputs.notify-id }}
           SOFTWARE_NAME: = ${{ github.event.inputs.software-name }}
@@ -72,8 +77,9 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
               ve1/bin/pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py
           else
-              echo "[INFO] Vendor type ${{ env.TEST_VENDOR_TYPE }}"
-              echo "[INFO] Notify ID ${{ env.TEST_NOTIFY_ID }}"
+              echo "[INFO] Dry run ${{ env.DRY_RUN }}"
+              echo "[INFO] Vendor type ${{ env.VENDOR_TYPE }}"
+              echo "[INFO] Notify ID ${{ env.NOTIFY_ID }}"
               echo "[INFO] Software Name ${{ env.SOFTWARE_NAME }}"
               echo "[INFO] Software Version ${{ env.SOFTWARE_VERSION }}"
               ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ on:
           description: 'Software Name'
           required: true
         software-version:
-          description: 'Software Name'
+          description: 'Software Version'
           required: true
 
 
@@ -62,10 +62,7 @@ jobs:
         if: ${{ steps.check_request.outputs.run-tests == 'true'}}
         env:
           CLUSTER_TOKEN: ${{ secrets.CLUSTER_TOKEN }}
-          TEST_REPO: ${{ secrets.TEST_REPO }}
-          FORK_REPO: ${{ secrets.FORK_REPO }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          API_URL: = ${{ github.event.pull_request._links.self.href }}
           VENDOR_TYPE: = ${{ github.event.inputs.vendor-type }}
           NOTIFY_ID: = ${{ github.event.inputs.notify-id }}
           SOFTWARE_NAME: = ${{ github.event.inputs.software-name }}
@@ -77,6 +74,7 @@ jobs:
           else
               echo "[INFO] Vendor type ${{ env.TEST_VENDOR_TYPE }}"
               echo "[INFO] Notify ID ${{ env.TEST_NOTIFY_ID }}"
-              echo "[INFO] Reason ${{ env.TEST_REASON }}"
+              echo "[INFO] Software Name ${{ env.SOFTWARE_NAME }}"
+              echo "[INFO] Software Version ${{ env.SOFTWARE_VERSION }}"
               ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,13 @@ on:
           description: 'Issue notification {OWNERS,none,<github id>}'
           required: true
           default: 'none'
-        reason:
-          description: 'Reason for running test to add to Issues'
-          required: false
+        software-name:
+          description: 'Software Name'
+          required: true
+        software-version:
+          description: 'Software Name'
+          required: true
+
 
 jobs:
   workflow-test:
@@ -62,16 +66,17 @@ jobs:
           FORK_REPO: ${{ secrets.FORK_REPO }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_URL: = ${{ github.event.pull_request._links.self.href }}
-          TEST_VENDOR_TYPE: = ${{ github.event.inputs.vendor-type }}
-          TEST_NOTIFY_ID: = ${{ github.event.inputs.notify-id }}
-          TEST_REASON: = ${{ github.event.inputs.reason }}
+          VENDOR_TYPE: = ${{ github.event.inputs.vendor-type }}
+          NOTIFY_ID: = ${{ github.event.inputs.notify-id }}
+          SOFTWARE_NAME: = ${{ github.event.inputs.software-name }}
+          SOFTWARE_VERSION: = ${{ github.event.inputs.software-version }}
         run: |
           # Run the wokflow tests
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-              echo "../ve1/bin/pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py"
+              echo "pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py"
           else
               echo "[INFO] Vendor type ${{ env.TEST_VENDOR_TYPE }}"
               echo "[INFO] Notify ID ${{ env.TEST_NOTIFY_ID }}"
               echo "[INFO] Reason ${{ env.TEST_REASON }}"
-              echo "../ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO"
+              echo "pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test Workflow
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, workflow_dispatch]
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
       inputs:
         dry-run:
@@ -34,6 +34,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ github.event.inputs.bot-token }}
+          fetch-depth: 0
 
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,10 +73,10 @@ jobs:
         run: |
           # Run the wokflow tests
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-              echo "pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py"
+              pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py
           else
               echo "[INFO] Vendor type ${{ env.TEST_VENDOR_TYPE }}"
               echo "[INFO] Notify ID ${{ env.TEST_NOTIFY_ID }}"
               echo "[INFO] Reason ${{ env.TEST_REASON }}"
-              echo "pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO"
+              pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,24 +4,25 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
-      inputs:
-        dry-run:
-          description: 'Run tests but do not create issues {true,false}'
-          required: true
-          default: 'true'
-        notify-id:
-          description: 'Issue notification {github id}'
-          required: false
-        vendor-type:
-          description: 'Vendor type {all,partner,redhat,community}'
-          required: true
-          default: 'all'
-        software-name:
-          description: 'Software Name'
-          required: true
-        software-version:
-          description: 'Software Version'
-          required: true
+    inputs:
+      dry-run:
+        description: 'Run tests but do not create issues {true,false}'
+        required: true
+        default: 'true'
+      notify-id:
+        description: 'Issue notification {github id}'
+        required: false
+        default: ''
+      vendor-type:
+        description: 'Vendor type {all,partner,redhat,community}'
+        required: true
+        default: 'all'
+      software-name:
+        description: 'Software Name'
+        required: true
+      software-version:
+        description: 'Software Version'
+        required: true
 
 
 jobs:
@@ -35,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          token: ${{ github.event.inputs.bot-token }}
+          token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
 
       - name: Set up Python 3.x Part 1
@@ -74,6 +75,8 @@ jobs:
           NOTIFY_ID: ${{ github.event.inputs.notify-id }}
           SOFTWARE_NAME: ${{ github.event.inputs.software-name }}
           SOFTWARE_VERSION: ${{ github.event.inputs.software-version }}
+          BOT_NAME: ${{ secrets.BOT_NAME }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           # Run the wokflow tests
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,77 @@
+name: Test Workflow
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, workflow_dispatch]
+  workflow_dispatch:
+      inputs:
+        vendor-type:
+          description: 'Vendor type {all,partner,redhat,community}'
+          required: true
+          default: 'all'
+        notify-id:
+          description: 'Issue notification {OWNERS,none,<github id>}'
+          required: true
+          default: 'none'
+        reason:
+          description: 'Reason for running test to add to Issues'
+          required: false
+
+jobs:
+  workflow-test:
+    name: Workflow Test
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.x Part 1
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Set up Python 3.x Part 2
+        run: |
+          # set up python requirements and scripts
+          python3 -m venv ve1
+          cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
+          cd scripts && ../ve1/bin/python3 setup.py install && cd ..
+
+      - name: Check Request
+        id: check_request
+        run: |
+          # check if workflow testing should run.
+          echo "Request type: $GITHUB_EVENT_NAME"
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+              echo "[INFO] check if PR contains only workflow changes and user is authorized"
+              ve1/bin/check-pr-for-ci --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
+          else
+              echo "[INFO] manual invocation - check if user is authorized"
+              ve1/bin/check-pr-for-ci --verify-user=${{ github.actor }}
+          fi
+
+      - name: Test CI Workflow
+        id: test_ci_workflow
+        if: ${{ steps.check_request.outputs.run-tests == 'true'}}
+        env:
+          CLUSTER_TOKEN: ${{ secrets.CLUSTER_TOKEN }}
+          TEST_REPO: ${{ secrets.TEST_REPO }}
+          FORK_REPO: ${{ secrets.FORK_REPO }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_URL: = ${{ github.event.pull_request._links.self.href }}
+          TEST_VENDOR_TYPE: = ${{ github.event.inputs.vendor-type }}
+          TEST_NOTIFY_ID: = ${{ github.event.inputs.notify-id }}
+          TEST_REASON: = ${{ github.event.inputs.reason }}
+        run: |
+          # Run the wokflow tests
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+              echo "../ve1/bin/pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py"
+          else
+              echo "[INFO] Vendor type ${{ env.TEST_VENDOR_TYPE }}"
+              echo "[INFO] Notify ID ${{ env.TEST_NOTIFY_ID }}"
+              echo "[INFO] Reason ${{ env.TEST_REASON }}"
+              echo "../ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ on:
         notify-id:
           description: 'Issue notification {github id}'
           required: false
-          default:
         vendor-type:
           description: 'Vendor type {all,partner,redhat,community}'
           required: true
@@ -67,11 +66,11 @@ jobs:
         env:
           CLUSTER_TOKEN: ${{ secrets.CLUSTER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: = ${{ github.event.inputs.dry-run }}
-          VENDOR_TYPE: = ${{ github.event.inputs.vendor-type }}
-          NOTIFY_ID: = ${{ github.event.inputs.notify-id }}
-          SOFTWARE_NAME: = ${{ github.event.inputs.software-name }}
-          SOFTWARE_VERSION: = ${{ github.event.inputs.software-version }}
+          DRY_RUN: ${{ github.event.inputs.dry-run }}
+          VENDOR_TYPE: ${{ github.event.inputs.vendor-type }}
+          NOTIFY_ID: ${{ github.event.inputs.notify-id }}
+          SOFTWARE_NAME: ${{ github.event.inputs.software-name }}
+          SOFTWARE_VERSION: ${{ github.event.inputs.software-version }}
         run: |
           # Run the wokflow tests
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,10 +73,10 @@ jobs:
         run: |
           # Run the wokflow tests
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-              pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py
+              ve1/bin/pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py
           else
               echo "[INFO] Vendor type ${{ env.TEST_VENDOR_TYPE }}"
               echo "[INFO] Notify ID ${{ env.TEST_NOTIFY_ID }}"
               echo "[INFO] Reason ${{ env.TEST_REASON }}"
-              pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO
+              ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=INFO
           fi

--- a/scripts/src/workflowtesting/checkprforci.py
+++ b/scripts/src/workflowtesting/checkprforci.py
@@ -56,7 +56,7 @@ def verify_user(username):
         data = open(owners_path).read()
         out = yaml.load(data, Loader=Loader)
         if username in out["approvers"]:
-            print(f"[INFO] {username} verified")
+            print(f"[INFO] {username} authorized")
             return True
         else:
            print(f"[ERROR] {username} cannot run tests")

--- a/scripts/src/workflowtesting/checkprforci.py
+++ b/scripts/src/workflowtesting/checkprforci.py
@@ -72,16 +72,16 @@ def main():
     args = parser.parse_args()
     if not args.api_url:
         if verify_user(args.username):
-            print(f"[INFO] User verified for manual invocation - run tests.")
+            print(f"[INFO] User authorized for manual invocation - run tests.")
             print(f"::set-output name=run-tests::true")
         else:
-            print(f"[INFO] User not verified for manual invocation - do not run tests.")
+            print(f"[INFO] User not authorized for manual invocation - do not run tests.")
     elif check_if_ci_only_is_modified(args.api_url):
         if verify_user(args.username):
-            print(f"[INFO] PR is workflow changes only and user is verified - run tests.")
+            print(f"[INFO] PR is workflow changes only and user is authorized - run tests.")
             print(f"::set-output name=run-tests::true")
         else:
-            print(f"[INFO] PR is workflow changes only but user is not verified - do not run tests.")
+            print(f"[INFO] PR is workflow changes only but user is not authorized - do not run tests.")
     else:
         print(f"[INFO] Non workflow changes were found - do not run tests")
 


### PR DESCRIPTION
New workflow for CI changes and manual invocation for live chart testing.

For manual invocation 5 values can be specified
- dry-run : run tests but do not create issues
   - mandatory
   - values: true,false
   - default: false
- vendor-type 
   - mandatory
   - values: all, partner., community or redhat
   - default: all
- notify-id 
   - optional
   - values: ```<github-id>```
   - default: nil
- software-name
   - mandatory
   - values: name of software being updated which made the test necessary 
   - default: nil
- software-version
   - mandatory
   - values: version of software being updated which made the test necessary 
   - default: nil
 
workflow does not verify values. Values are set as environment variables for tests:
```
          DRY_RUN: = ${{ github.event.inputs.dry-run }}
          VENDOR_TYPE: = ${{ github.event.inputs.vendor-type }}
          NOTIFY_ID: = ${{ github.event.inputs.notify-id }}
          SOFTWARE_NAME: = ${{ github.event.inputs.software-name }}
          SOFTWARE_VERSION: = ${{ github.event.inputs.software-version }}
 ```