### PR TITLE
tests: add dry run and notify ids

### DIFF
--- a/tests/functional/notifier.py
+++ b/tests/functional/notifier.py
@@ -92,9 +92,6 @@ def create_verification_issue(chart_name, chart_owners, report_url, software_nam
     access_token -- An optional github access token secret. If not passed will try to get from GITHUB_AUTH_TOKEN environment variable\n
     """
 
-    if os.environ.get('NOTIFY_ID'):
-        chart_owners = [os.environ.get('NOTIFY_ID')]
-
     title = f"Action needed for {chart_name} after a certification dependency change"
 
     report_result = "some chart checks have failed. Consider submiting a new chart version with the appropiate corrections"
@@ -121,9 +118,6 @@ def create_version_change_issue(chart_name, chart_owners, software_name, softwar
     software_version -- The softwared dependency version used\n
     access_token -- An optional github access token secret. If not passed will try to get from GITHUB_AUTH_TOKEN environment variable\n
     """
-
-    if os.environ.get('NOTIFY_ID'):
-        chart_owners = [os.environ.get('NOTIFY_ID')]
 
     title = f"Action needed for {chart_name} after a certification dependency change"
 

--- a/tests/functional/test_submitted_charts.py
+++ b/tests/functional/test_submitted_charts.py
@@ -48,7 +48,8 @@ def secrets():
         pr_base_branch: str
         base_branches: list
         pr_branches: list
-        is_prod: bool
+        dry_run: bool
+        notify_id: list
 
         submitted_charts: list = None
         owners_file_content: str = """\
@@ -67,13 +68,21 @@ vendor:
         chart_name, chart_version = get_name_and_version_from_report(
             test_report)
 
-    # Accepts 'True' or 'False', depending on whether we want to tag chart owners, or bot for testing
-    is_prod = os.environ.get("IS_PROD")
-    if not is_prod:
-        # Default to False to avoid spamming tags to chart owners
-        is_prod = False
+    # Accepts 'True' or 'False', depending on whether we want to notify
+    dry_run = os.environ.get("DRY_RUN")
+    if not dry_run:
+        # Default to dry run to avoid spamming notifications
+        dry_run = True
     else:
-        is_prod = is_prod == 'True'
+        dry_run = dry_run == 'true'
+
+    # Accepts comma separated Github IDs or empty strings to override people to tag in notifications
+    notify_id = os.environ.get("NOTIFY_ID")
+    if notify_id:
+        notify_id = [vt.strip() for vt in notify_id.split(',')]
+    else:
+        # Default to not override, i.e. use chart owners
+        notify_id = []
 
     software_name = os.environ.get("SOFTWARE_NAME")
     if not software_name:
@@ -113,8 +122,8 @@ vendor:
     repo.git.push(f'https://x-access-token:{bot_token}@github.com/{test_repo}',
                   f'HEAD:refs/heads/{pr_base_branch}', '-f')
 
-    secrets = Secret(software_name, software_version, test_repo, bot_name,
-                     bot_token, vendor_type, pr_base_branch, base_branches, pr_branches, is_prod)
+    secrets = Secret(software_name, software_version, test_repo, bot_name, bot_token,
+                     vendor_type, pr_base_branch, base_branches, pr_branches, dry_run, notify_id)
     yield secrets
 
     # Teardown step to cleanup branches
@@ -171,6 +180,15 @@ def workflow_is_triggered():
 @then("submission tests are run for existing charts")
 def submission_tests_run_for_submitted_charts(secrets):
     """submission tests are run for existing charts."""
+
+    # Don't notify on dry runs, default to True
+    dry_run = True
+    if not secrets.dry_run:
+        # Don't notify if not triggerd on PROD_REPO and PROD_BRANCH
+        triggered_branch = os.environ.get("GITHUB_REF").split('/')[-1]
+        triggered_repo = os.environ.get("GITHUB_REPOSITORY")
+        if triggered_repo == PROD_REPO and triggered_branch == PROD_BRANCH:
+            dry_run = False
 
     with TemporaryDirectory(prefix='tci-') as temp_dir:
         owners_table = dict()
@@ -250,19 +268,21 @@ def submission_tests_run_for_submitted_charts(secrets):
             values = {'bot_name': secrets.bot_name,
                       'vendor': vendor_name, 'chart_name': chart_name}
             content = Template(secrets.owners_file_content).substitute(values)
-            # Use bot account for notifications unless in production
-            if secrets.is_prod:
-                with open(f'{chart_dir}/OWNERS', 'r') as fd:
-                    try:
-                        owners = yaml.safe_load(fd)
-                        # Pick owner ids for notification
-                        owners_table[chart_dir] = [
-                            owner.get(['githubUsername'], '') for owner in owners['users']]
-                    except yaml.YAMLError as err:
-                        logger.warning(
-                            f"Error parsing OWNERS of {chart_dir}: {err}")
-            else:
-                owners_table[chart_dir] = [secrets.bot_name]
+
+            # Don't send notifications on dry runs
+            if not dry_run:
+                if len(secrets.notify_id) == 0:
+                    with open(f'{chart_dir}/OWNERS', 'r') as fd:
+                        try:
+                            owners = yaml.safe_load(fd)
+                            # Pick owner ids for notification
+                            owners_table[chart_dir] = [
+                                owner.get(['githubUsername'], '') for owner in owners['users']]
+                        except yaml.YAMLError as err:
+                            logger.warning(
+                                f"Error parsing OWNERS of {chart_dir}: {err}")
+                else:
+                    owners_table[chart_dir] = secrets.notify_id
             with open(f'{chart_dir}/OWNERS', 'w') as fd:
                 fd.write(content)
 
@@ -308,20 +328,21 @@ def submission_tests_run_for_submitted_charts(secrets):
             conclusion = get_run_result(secrets, run_id)
 
             # Send notification to owner through GitHub issues
-            r = github_api(
-                'get', f'repos/{secrets.test_repo}/actions/runs/{run_id}', secrets.bot_token)
-            run = r.json()
-            run_html_url = run['html_url']
-            chart_dir = f'charts/{vendor_type}/{vendor_name}/{chart_name}'
-            chart_owners = owners_table[chart_dir]
-            pass_verification = conclusion == 'success'
-            os.environ['GITHUB_ORGANIZATION'] = PROD_REPO.split('/')[0]
-            os.environ['GITHUB_REPO'] = PROD_REPO.split('/')[1]
-            os.environ['GITHUB_AUTH_TOKEN'] = secrets.bot_token
-            logger.info(
-                f"Send notification to '{chart_owners}' about verification result of '{chart}'")
-            create_verification_issue(chart_name, chart_owners, run_html_url, secrets.software_name,
-                                      secrets.software_version, pass_verification, secrets.bot_token)
+            if not dry_run:
+                r = github_api(
+                    'get', f'repos/{secrets.test_repo}/actions/runs/{run_id}', secrets.bot_token)
+                run = r.json()
+                run_html_url = run['html_url']
+                chart_dir = f'charts/{vendor_type}/{vendor_name}/{chart_name}'
+                chart_owners = owners_table[chart_dir]
+                pass_verification = conclusion == 'success'
+                os.environ['GITHUB_ORGANIZATION'] = PROD_REPO.split('/')[0]
+                os.environ['GITHUB_REPO'] = PROD_REPO.split('/')[1]
+                os.environ['GITHUB_AUTH_TOKEN'] = secrets.bot_token
+                logger.info(
+                    f"Send notification to '{chart_owners}' about verification result of '{chart}'")
+                create_verification_issue(chart_name, chart_owners, run_html_url, secrets.software_name,
+                                          secrets.software_version, pass_verification, secrets.bot_token)
 
             if conclusion == 'success':
                 logger.info(f"Workflow run for {chart} was 'success'")


### PR DESCRIPTION
Add DRY_RUN and NOTIFY_ID to guard the conditions for notifications.
Only notify when DRY_RUN and 'false', NOTIFY_ID is empty string, and the
workflow is triggered on openshift-helm-charts/charts:main.

Signed-off-by: Allen Bai <abai@redhat.com>