### PR TITLE
tests: fix chart src testing when src dir already exists

### DIFF
--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -231,10 +231,16 @@ def the_user_has_created_a_error_free_chart_src_with_report(secrets):
                       f'HEAD:refs/heads/{secrets.base_branch}', '-f')
 
         # Unzip files into temporary directory for PR submission
-        with tarfile.open(secrets.test_chart, 'r') as fd:
-            fd.extractall(f'{chart_dir}/{secrets.chart_version}')
-            shutil.move(f'{chart_dir}/{secrets.chart_version}/{secrets.chart_name}',
-                      f'{chart_dir}/{secrets.chart_version}/src')
+        try:
+            logger.info(f"Remove existing local '{chart_dir}/{secrets.chart_version}/src'")
+            shutil.rmtree(f'{chart_dir}/{secrets.chart_version}/src')
+        except FileNotFoundError:
+            logger.info(f"'{chart_dir}/{secrets.chart_version}/src' does not exist")
+        finally:
+            with tarfile.open(secrets.test_chart, 'r') as fd:
+                fd.extractall(f'{chart_dir}/{secrets.chart_version}')
+                os.rename(f'{chart_dir}/{secrets.chart_version}/{secrets.chart_name}',
+                            f'{chart_dir}/{secrets.chart_version}/src')
 
         # Copy report to temporary location and push to test_repo:pr_branch
         logger.info(

--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -231,16 +231,7 @@ def the_user_has_created_a_error_free_chart_src_with_report(secrets):
                       f'HEAD:refs/heads/{secrets.base_branch}', '-f')
 
         # Unzip files into temporary directory for PR submission
-        try:
-            logger.info(f"Remove existing local '{chart_dir}/{secrets.chart_version}/src'")
-            shutil.rmtree(f'{chart_dir}/{secrets.chart_version}/src')
-        except FileNotFoundError:
-            logger.info(f"'{chart_dir}/{secrets.chart_version}/src' does not exist")
-        finally:
-            with tarfile.open(secrets.test_chart, 'r') as fd:
-                fd.extractall(f'{chart_dir}/{secrets.chart_version}')
-                os.rename(f'{chart_dir}/{secrets.chart_version}/{secrets.chart_name}',
-                            f'{chart_dir}/{secrets.chart_version}/src')
+        extract_chart_tgz(secrets.test_chart, f'{chart_dir}/{secrets.chart_version}', secrets, logger)
 
         # Copy report to temporary location and push to test_repo:pr_branch
         logger.info(

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -232,16 +232,7 @@ def the_user_has_created_a_error_free_chart_src(secrets):
                       f'HEAD:refs/heads/{secrets.base_branch}', '-f')
 
         # Unzip files into temporary directory for PR submission
-        try:
-            logger.info(f"Remove existing local '{chart_dir}/{secrets.chart_version}/src'")
-            shutil.rmtree(f'{chart_dir}/{secrets.chart_version}/src')
-        except FileNotFoundError:
-            logger.info(f"'{chart_dir}/{secrets.chart_version}/src' does not exist")
-        finally:
-            with tarfile.open(secrets.test_chart, 'r') as fd:
-                fd.extractall(f'{chart_dir}/{secrets.chart_version}')
-                os.rename(f'{chart_dir}/{secrets.chart_version}/{secrets.chart_name}',
-                            f'{chart_dir}/{secrets.chart_version}/src')
+        extract_chart_tgz(secrets.test_chart, f'{chart_dir}/{secrets.chart_version}', secrets, logger)
 
         # Push chart src files to test_repo:pr_branch
         repo.git.add(f'{chart_dir}/{secrets.chart_version}/src')

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -232,10 +232,16 @@ def the_user_has_created_a_error_free_chart_src(secrets):
                       f'HEAD:refs/heads/{secrets.base_branch}', '-f')
 
         # Unzip files into temporary directory for PR submission
-        with tarfile.open(secrets.test_chart, 'r') as fd:
-            fd.extractall(f'{chart_dir}/{secrets.chart_version}')
-            shutil.move(f'{chart_dir}/{secrets.chart_version}/{secrets.chart_name}',
-                        f'{chart_dir}/{secrets.chart_version}/src')
+        try:
+            logger.info(f"Remove existing local '{chart_dir}/{secrets.chart_version}/src'")
+            shutil.rmtree(f'{chart_dir}/{secrets.chart_version}/src')
+        except FileNotFoundError:
+            logger.info(f"'{chart_dir}/{secrets.chart_version}/src' does not exist")
+        finally:
+            with tarfile.open(secrets.test_chart, 'r') as fd:
+                fd.extractall(f'{chart_dir}/{secrets.chart_version}')
+                os.rename(f'{chart_dir}/{secrets.chart_version}/{secrets.chart_name}',
+                            f'{chart_dir}/{secrets.chart_version}/src')
 
         # Push chart src files to test_repo:pr_branch
         repo.git.add(f'{chart_dir}/{secrets.chart_version}/src')


### PR DESCRIPTION
When there's already a `src` directory under the target location under `charts/`,
     the test case will fail because the code will _move_ the test chart
     _into_ the `src` directory, which will result in mismatched SHA value.

This fixes the issue by removing the src directory in the runner and
test with the test charts.

Signed-off-by: Allen Bai <abai@redhat.com>