### PR TITLE
tests: use bot sandbox repo for testing

### DIFF
--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -13,7 +13,7 @@ from retrying import retry
 
 GITHUB_BASE_URL = 'https://api.github.com'
 # The sandbox repository where we run all our tests on
-TEST_REPO = 'openshift-helm-charts/sandbox'
+TEST_REPO = 'openshift-helm-charts-bot/sandbox'
 # The prod repository where we create notification issues
 PROD_REPO = 'openshift-helm-charts/charts'
 # The prod branch where we store all chart files


### PR DESCRIPTION
There are two options for sandbox locatons:
1. https://github.com/openshift-helm-charts/sandbox
2. https://github.com/openshift-helm-charts-bot/sandbox

The advantage of using `openshift-helm-charts` is that it's officially under the organization. But the disadvatage is that it is not a fork so syncing between prod `charts` and `sandbox` repo can be tricky (can be implemented as an action on push to `main`), and the bot account needs permission to push to this repo.

The advantage of using `bot sandbox` is that it's a fork so syncing can be done by existing tools such as https://github.com/apps/pull, and no extra permission is needed for bot account.

I propose we use the fork as testing repo for quick start, because we need an action to sync between `charts` and `sandbox` repos if we go with option#1.

Signed-off-by: Allen Bai <abai@redhat.com>