### PR TITLE
workflow: use pull_request_target to get secrets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test Workflow
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
     inputs:
@@ -36,6 +36,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
 
@@ -56,7 +58,7 @@ jobs:
         run: |
           # check if workflow testing should run.
           echo "Request type: $GITHUB_EVENT_NAME"
-          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+          if [ "$GITHUB_EVENT_NAME" == "pull_request_target" ]; then
               echo "[INFO] check if PR contains only workflow changes and user is authorized"
               ve1/bin/check-pr-for-ci --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
           else
@@ -79,7 +81,7 @@ jobs:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           # Run the wokflow tests
-          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+          if [ "$GITHUB_EVENT_NAME" == "pull_request_target" ]; then
               ve1/bin/pytest tests/ --log-cli-level=INFO --ignore=tests/functional/test_submitted_charts.py
           else
               echo "[INFO] Dry run ${{ env.DRY_RUN }}"

--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -85,7 +85,7 @@ vendor:
     repo.git.push(f'https://x-access-token:{bot_token}@github.com/{test_repo}',
                   f'HEAD:refs/heads/{current_branch}', '-f')
 
-    base_branch = 'vault-0.13.0-src-with-report'
+    base_branch = f'chart-src-with-report-{current_branch}'
     pr_branch = base_branch + '-pr'
 
     secrets = Secret(test_repo, bot_name, bot_token, base_branch, pr_branch)
@@ -95,10 +95,6 @@ vendor:
     repo.git.worktree('prune')
 
     if github_actions:
-        logger.info(f"Delete local '{head_sha}' branch")
-        repo.git.checkout('main')
-        repo.git.branch('-D', head_sha)
-
         logger.info(f"Delete remote '{head_sha}' branch")
         github_api(
             'delete', f'repos/{secrets.test_repo}/git/refs/heads/{head_sha}', secrets.bot_token)
@@ -156,7 +152,7 @@ def the_user_has_created_a_error_free_chart_src_with_report(secrets):
         secrets.pr_branch = f'{secrets.base_branch}-pr'
 
         repo = git.Repo(os.getcwd())
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         if os.environ.get('WORKFLOW_DEVELOPMENT'):
             logger.info("Wokflow development enabled")
             repo.git.add(A=True)
@@ -182,7 +178,7 @@ def the_user_has_created_a_error_free_chart_src_with_report(secrets):
 
         os.chdir(temp_dir)
         repo = git.Repo(temp_dir)
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         repo.git.checkout('-b', secrets.base_branch)
         chart_dir = f'charts/{secrets.vendor_type}/{secrets.vendor}/{secrets.chart_name}'
         pathlib.Path(

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -83,7 +83,7 @@ vendor:
     repo.git.push(f'https://x-access-token:{bot_token}@github.com/{test_repo}',
                   f'HEAD:refs/heads/{current_branch}', '-f')
 
-    base_branch = 'vault-0.13.0-src-without-report'
+    base_branch = f'chart-src-without-report-{current_branch}'
     pr_branch = base_branch + '-pr'
 
     secrets = Secret(test_repo, bot_name, bot_token, base_branch, pr_branch)
@@ -93,10 +93,6 @@ vendor:
     repo.git.worktree('prune')
 
     if github_actions:
-        logger.info(f"Delete local '{head_sha}' branch")
-        repo.git.checkout('main')
-        repo.git.branch('-D', head_sha)
-
         logger.info(f"Delete remote '{head_sha}' branch")
         github_api(
             'delete', f'repos/{secrets.test_repo}/git/refs/heads/{head_sha}', secrets.bot_token)
@@ -155,7 +151,7 @@ def the_user_has_created_a_error_free_chart_src(secrets):
 
         repo = git.Repo(os.getcwd())
         set_git_username_email(repo, secrets.bot_name,
-                               f'{secrets.bot_name}@test.email')
+                               GITHUB_ACTIONS_BOT_EMAIL)
         if os.environ.get('WORKFLOW_DEVELOPMENT'):
             logger.info("Wokflow development enabled")
             repo.git.add(A=True)
@@ -182,7 +178,7 @@ def the_user_has_created_a_error_free_chart_src(secrets):
         os.chdir(temp_dir)
         repo = git.Repo(temp_dir)
         set_git_username_email(repo, secrets.bot_name,
-                               f'{secrets.bot_name}@test.email')
+                               GITHUB_ACTIONS_BOT_EMAIL)
         repo.git.checkout('-b', secrets.base_branch)
         chart_dir = f'charts/{secrets.vendor_type}/{secrets.vendor}/{secrets.chart_name}'
         pathlib.Path(

--- a/tests/functional/test_chart_tar_with_report.py
+++ b/tests/functional/test_chart_tar_with_report.py
@@ -84,7 +84,7 @@ vendor:
     repo.git.push(f'https://x-access-token:{bot_token}@github.com/{test_repo}',
                   f'HEAD:refs/heads/{current_branch}', '-f')
 
-    base_branch = 'vault-0.13.0-tar-with-report'
+    base_branch = f'chart-tar-with-report-{current_branch}'
     pr_branch = base_branch + '-pr'
 
     secrets = Secret(test_repo, bot_name, bot_token, base_branch, pr_branch)
@@ -94,10 +94,6 @@ vendor:
     repo.git.worktree('prune')
 
     if github_actions:
-        logger.info(f"Delete local '{head_sha}' branch")
-        repo.git.checkout('main')
-        repo.git.branch('-D', head_sha)
-
         logger.info(f"Delete remote '{head_sha}' branch")
         github_api(
             'delete', f'repos/{secrets.test_repo}/git/refs/heads/{head_sha}', secrets.bot_token)
@@ -155,7 +151,7 @@ def the_user_has_created_a_error_free_chart_tar_with_report(secrets):
         secrets.pr_branch = f'{secrets.base_branch}-pr'
 
         repo = git.Repo(os.getcwd())
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         if os.environ.get('WORKFLOW_DEVELOPMENT'):
             logger.info("Wokflow development enabled")
             repo.git.add(A=True)
@@ -181,7 +177,7 @@ def the_user_has_created_a_error_free_chart_tar_with_report(secrets):
 
         os.chdir(temp_dir)
         repo = git.Repo(temp_dir)
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         repo.git.checkout('-b', secrets.base_branch)
         chart_dir = f'charts/{secrets.vendor_type}/{secrets.vendor}/{secrets.chart_name}'
         pathlib.Path(

--- a/tests/functional/test_chart_tar_without_report.py
+++ b/tests/functional/test_chart_tar_without_report.py
@@ -83,7 +83,7 @@ vendor:
     repo.git.push(f'https://x-access-token:{bot_token}@github.com/{test_repo}',
                   f'HEAD:refs/heads/{current_branch}', '-f')
 
-    base_branch = 'vault-0.13.0-tar-without-report'
+    base_branch = f'chart-tar-without-report-{current_branch}'
     pr_branch = base_branch + '-pr'
 
     secrets = Secret(test_repo, bot_name, bot_token, base_branch, pr_branch)
@@ -94,10 +94,6 @@ vendor:
     repo.git.worktree('prune')
 
     if github_actions:
-        logger.info(f"Delete local '{head_sha}' branch")
-        repo.git.checkout('main')
-        repo.git.branch('-D', head_sha)
-
         logger.info(f"Delete remote '{head_sha}' branch")
         github_api(
             'delete', f'repos/{secrets.test_repo}/git/refs/heads/{head_sha}', secrets.bot_token)
@@ -155,7 +151,7 @@ def the_user_has_created_a_error_free_chart_tar(secrets):
         secrets.pr_branch = f'{secrets.base_branch}-pr'
 
         repo = git.Repo(os.getcwd())
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         if os.environ.get('WORKFLOW_DEVELOPMENT'):
             logger.info("Wokflow development enabled")
             repo.git.add(A=True)
@@ -181,7 +177,7 @@ def the_user_has_created_a_error_free_chart_tar(secrets):
 
         os.chdir(temp_dir)
         repo = git.Repo(temp_dir)
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         repo.git.checkout('-b', secrets.base_branch)
         chart_dir = f'charts/{secrets.vendor_type}/{secrets.vendor}/{secrets.chart_name}'
         pathlib.Path(

--- a/tests/functional/test_report_only_no_errors.py
+++ b/tests/functional/test_report_only_no_errors.py
@@ -82,7 +82,7 @@ vendor:
     repo.git.push(f'https://x-access-token:{bot_token}@github.com/{test_repo}',
                   f'HEAD:refs/heads/{current_branch}', '-f')
 
-    base_branch = 'vault-0.13.0-report-only'
+    base_branch = f'report-only-{current_branch}'
     pr_branch = base_branch + '-pr'
 
     secrets = Secret(test_repo, bot_name, bot_token, base_branch, pr_branch)
@@ -92,10 +92,6 @@ vendor:
     repo.git.worktree('prune')
 
     if github_actions:
-        logger.info(f"Delete local '{head_sha}' branch")
-        repo.git.checkout('main')
-        repo.git.branch('-D', head_sha)
-
         logger.info(f"Delete remote '{head_sha}' branch")
         github_api(
             'delete', f'repos/{secrets.test_repo}/git/refs/heads/{head_sha}', secrets.bot_token)
@@ -153,7 +149,7 @@ def the_user_has_created_a_report_without_errors(secrets):
         secrets.pr_branch = f'{secrets.base_branch}-pr'
 
         repo = git.Repo(os.getcwd())
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         if os.environ.get('WORKFLOW_DEVELOPMENT'):
             logger.info("Wokflow development enabled")
             repo.git.add(A=True)
@@ -179,7 +175,7 @@ def the_user_has_created_a_report_without_errors(secrets):
 
         os.chdir(temp_dir)
         repo = git.Repo(temp_dir)
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         repo.git.checkout('-b', secrets.base_branch)
         chart_dir = f'charts/{secrets.vendor_type}/{secrets.vendor}/{secrets.chart_name}'
         pathlib.Path(

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -20,6 +20,8 @@ PROD_REPO = 'openshift-helm-charts/charts'
 PROD_BRANCH = 'main'
 # This is used to find chart certification workflow run id
 CERTIFICATION_CI_NAME = 'CI'
+# GitHub actions bot email for git email
+GITHUB_ACTIONS_BOT_EMAIL = '41898282+github-actions[bot]@users.noreply.github.com'
 
 
 @retry(stop_max_delay=30_000, wait_fixed=1000)


### PR DESCRIPTION
Previously we used `pull_reqeust` as event target but GitHub does not
allow secret access on pull_request because of security reasons:
https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow.

This fix uses `pull_request_target` to access secrets and use the
bot_token.

Signed-off-by: Allen Bai <abai@redhat.com>