### PR TITLE
tests: fix pull request failure when running in sandbox

### DIFF
--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -255,13 +255,7 @@ def the_user_has_created_a_error_free_chart_src_with_report(secrets):
 @when("the redhat associate sends a pull request with the vault source chart and report")
 def the_user_sends_the_pull_request(secrets):
     """The user sends the pull request with the chart source files."""
-
-    actions_bot_name = 'github-actions[bot]'
-    if secrets.bot_name == actions_bot_name:
-        head = secrets.pr_branch
-    else:
-        head = f'{secrets.bot_name}:{secrets.pr_branch}'
-    data = {'head': head, 'base': secrets.base_branch,
+    data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
             'title': secrets.pr_branch}
 
     logger.info(

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -245,13 +245,7 @@ def the_user_has_created_a_error_free_chart_src(secrets):
 @when("the redhat associate sends a pull request with the vault source chart")
 def the_user_sends_the_pull_request_with_the_chart_src(secrets):
     """The user sends the pull request with the chart source files."""
-
-    actions_bot_name = 'github-actions[bot]'
-    if secrets.bot_name == actions_bot_name:
-        head = secrets.pr_branch
-    else:
-        head = f'{secrets.bot_name}:{secrets.pr_branch}'
-    data = {'head': head, 'base': secrets.base_branch,
+    data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
             'title': secrets.pr_branch}
 
     logger.info(

--- a/tests/functional/test_chart_tar_with_report.py
+++ b/tests/functional/test_chart_tar_with_report.py
@@ -256,13 +256,7 @@ def the_user_has_created_a_error_free_chart_tar_with_report(secrets):
 @when("the redhat associate sends a pull request with the vault tar chart and report")
 def the_user_sends_the_pull_request(secrets):
     """The user sends the pull request with the chart tar files."""
-
-    actions_bot_name = 'github-actions[bot]'
-    if secrets.bot_name == actions_bot_name:
-        head = secrets.pr_branch
-    else:
-        head = f'{secrets.bot_name}:{secrets.pr_branch}'
-    data = {'head': head, 'base': secrets.base_branch,
+    data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
             'title': secrets.pr_branch}
 
     logger.info(

--- a/tests/functional/test_chart_tar_without_report.py
+++ b/tests/functional/test_chart_tar_without_report.py
@@ -247,13 +247,7 @@ def the_user_has_created_a_error_free_chart_tar(secrets):
 @when("the redhat associate sends a pull request with the vault tar chart")
 def the_user_sends_the_pull_request_with_the_chart_tar(secrets):
     """The user sends the pull request with the chart tar file."""
-
-    actions_bot_name = 'github-actions[bot]'
-    if secrets.bot_name == actions_bot_name:
-        head = secrets.pr_branch
-    else:
-        head = f'{secrets.bot_name}:{secrets.pr_branch}'
-    data = {'head': head, 'base': secrets.base_branch,
+    data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
             'title': secrets.pr_branch}
 
     logger.info(

--- a/tests/functional/test_report_only_no_errors.py
+++ b/tests/functional/test_report_only_no_errors.py
@@ -247,13 +247,7 @@ def the_user_has_created_a_report_without_errors(secrets):
 @when("the redhat associate sends the pull request with the report")
 def the_user_sends_the_pull_request_with_the_report(secrets):
     """The user sends the pull request with the report."""
-
-    actions_bot_name = 'github-actions[bot]'
-    if secrets.bot_name == actions_bot_name:
-        head = secrets.pr_branch
-    else:
-        head = f'{secrets.bot_name}:{secrets.pr_branch}'
-    data = {'head': head, 'base': secrets.base_branch,
+    data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
             'title': secrets.pr_branch}
 
     logger.info(

--- a/tests/functional/test_submitted_charts.py
+++ b/tests/functional/test_submitted_charts.py
@@ -189,7 +189,7 @@ def submission_tests_run_for_submitted_charts(secrets):
         pr_number_list = []
 
         repo = git.Repo(os.getcwd())
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         if os.environ.get('WORKFLOW_DEVELOPMENT'):
             logger.info("Wokflow development enabled")
             repo.git.add(A=True)
@@ -209,7 +209,7 @@ def submission_tests_run_for_submitted_charts(secrets):
         # Run submission flow test with charts in PROD_REPO:PROD_BRANCH
         os.chdir(temp_dir)
         repo = git.Repo(temp_dir)
-        set_git_username_email(repo, secrets.bot_name, f'{secrets.bot_name}@test.email')
+        set_git_username_email(repo, secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         repo.git.fetch(
             f'https://github.com/{PROD_REPO}.git', f'{PROD_BRANCH}:{PROD_BRANCH}', '-f')
         repo.git.checkout(PROD_BRANCH, 'charts')
@@ -325,12 +325,7 @@ def submission_tests_run_for_submitted_charts(secrets):
                           f'HEAD:refs/heads/{pr_branch}', '-f')
 
             # Create PR from test_repo:pr_branch to test_repo:base_branch
-            actions_bot_name = 'github-actions[bot]'
-            if secrets.bot_name == actions_bot_name:
-                head = pr_branch
-            else:
-                head = f'{secrets.bot_name}:{pr_branch}'
-            data = {'head': head, 'base': base_branch,
+            data = {'head': pr_branch, 'base': base_branch,
                     'title': pr_branch}
 
             logger.info(


### PR DESCRIPTION
It wasn't causing trouble previously because the way I tested it. I was testing in the bot sanbox repository, which is a fork of the team sandbox repo so the `username:branch` is available in the gihutb repo network (https://github.com/abai-test-bot). But in the team sandbox repo since there's no temporary testing branch nor a fork created for the team test bot, the `username:branch` returns invalid head API response (https://github.com/openshift-helm-charts-bot/sandbox/runs/3284276607?check_suite_focus=true#step:6:187)

Solves: https://github.com/openshift-helm-charts/charts/runs/3284145973?check_suite_focus=true
Refs: 
* Team bot account repos: https://github.com/openshift-helm-charts-bot
* Github APIs for PRs: https://docs.github.com/en/rest/reference/pulls#create-a-pull-request

Signed-off-by: Allen Bai <abai@redhat.com>