### PR TITLE
workflow: update action version to fix missing report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,7 @@ jobs:
 
       - name: Release
         if: ${{ steps.release-charts.outputs.tag != '' }}
-        uses: softprops/action-gh-release@v0.1.5
+        uses: softprops/action-gh-release@v0.1.12
         continue-on-error: true
         with:
           tag_name: ${{ steps.release-charts.outputs.tag }}


### PR DESCRIPTION
Fixes a bug where chart only submissions are missing report.yaml in the release assets: https://github.com/openshift-helm-charts/charts/releases/tag/hashicorp-vault-0.14.0

This is caused by the old version of the `softprops/action-gh-release` action, new version fixed this.

Pre fix: https://github.com/openshift-helm-charts/sandbox/runs/3291954374?check_suite_focus=true#step:29:12
Post fix: https://github.com/openshift-helm-charts/sandbox/runs/3292903339?check_suite_focus=true

Signed-off-by: Allen Bai <abai@redhat.com>