### PR TITLE
workflow: cleanup and add clear PR messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Set up Python 3.x Part 2
         run: |
@@ -51,10 +51,11 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
         run: |
-         INDEX_BRANCH=$(if [ "${GITHUB_REF}" = "refs/heads/main" ]; then echo "refs/heads/gh-pages"; else echo "${GITHUB_REF}-gh-pages"; fi)
-          ./ve1/bin/sanity-check-pr --index-branch=${INDEX_BRANCH} --repository=${{ github.repository }} --api-url=${{ github.event.pull_request._links.self.href }}
+          INDEX_BRANCH=$(if [ "${GITHUB_REF}" = "refs/heads/main" ]; then echo "refs/heads/gh-pages"; else echo "${GITHUB_REF}-gh-pages"; fi)
+           ./ve1/bin/sanity-check-pr --index-branch=${INDEX_BRANCH} --repository=${{ github.repository }} --api-url=${{ github.event.pull_request._links.self.href }}
 
-      - uses: actions/github-script@v3
+      - name: Add 'sanity-ok' label
+        uses: actions/github-script@v3
         if: ${{ steps.sanity_check_pr_content.outcome == 'success'}}
         continue-on-error: true
         with:
@@ -67,7 +68,8 @@ jobs:
               labels: ['sanity-ok']
             })
 
-      - uses: actions/github-script@v3
+      - name: Remove 'sanity-ok' label
+        uses: actions/github-script@v3
         if: ${{ steps.sanity_check_pr_content.outcome == 'failure'}}
         continue-on-error: true
         with:
@@ -86,7 +88,7 @@ jobs:
           echo "The 'Sanity Check PR Content' step has failed."
           exit 1
 
-      - name: 'Remove label from PR'
+      - name: Remove 'authorized-request' label from PR
         uses: actions/github-script@v3
         if: steps.check_ci_changes.outputs.run-tests != 'true'
         continue-on-error: true
@@ -139,7 +141,7 @@ jobs:
           echo "::set-output name=repository::${REPO}"
         shell: bash
 
-      - name: 'Verify PR - generate report'
+      - name: Verify PR - generate report
         id: verify_pr
         if: steps.check_ci_changes.outputs.run-tests != 'true'
         env:
@@ -158,7 +160,6 @@ jobs:
           ../ve1/bin/chart-pr-review --directory=../pr --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
           cd ..
 
-
       - name: Delete Namespace
         if: steps.install-oc.outputs.oc-installed == 'true'
         env:
@@ -173,14 +174,14 @@ jobs:
         run: |
           ve1/bin/pr-artifact --directory=./pr --pr-number=${{ github.event.number }} --api-url=${{ github.event.pull_request._links.self.href }}
 
-      - name: 'Prepare PR comment'
+      - name: Prepare PR comment
         if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
         env:
           SANITY_ERROR_MESSAGE: ${{ steps.sanity_check_pr_content.outputs.sanity-error-message }}
         run: |
           python3 scripts/prepare_pr_comment.py ${{ steps.sanity_check_pr_content.outcome }} ${{ steps.verify_pr.conclusion }} ${{ github.repository }}
 
-      - name: 'Comment on PR'
+      - name: Comment on PR
         if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
         uses: actions/github-script@v3
         with:
@@ -196,7 +197,7 @@ jobs:
               body: comment
             });
 
-      - name: 'Add label to PR'
+      - name: Add 'authorized-request' label to PR
         if: ${{ always() && steps.sanity_check_pr_content.outcome == 'success' && steps.check_ci_changes.outputs.run-tests != 'true' }}
         uses: actions/github-script@v3
         with:
@@ -214,14 +215,14 @@ jobs:
                 labels: ['authorized-request']
             })};
 
-      - name: 'Approve PR'
+      - name: Approve PR
         id: approve_pr
         if: ${{ steps.verify_pr.conclusion == 'success' }}
         uses: hmarr/auto-approve-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Merge PR'
+      - name: Merge PR
         id: merge_pr
         if: ${{ steps.approve_pr.conclusion == 'success' }}
         uses: pascalgn/automerge-action@v0.13.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Exit if CI tests will run
         id: exit_if_ci
-        if: steps.check_ci_changes.outputs.run-tests == 'true' || steps.check_ci_changes.outputs.workflow-only-but-not-authorized == 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests == 'true' || steps.check_ci_changes.outputs.workflow-only-but-not-authorized == 'true' }}
         run: |
           # exit: workflow testing will run.
           echo "The PR is workflow changes only - do not continue."
@@ -46,7 +46,7 @@ jobs:
 
       - name: Sanity Check PR Content
         id: sanity_check_pr_content
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         continue-on-error: true
         env:
           GITHUB_REF: ${{ github.ref }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Remove 'authorized-request' label from PR
         uses: actions/github-script@v3
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
             })
 
       - name: Checkout
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Verify PR - generate report
         id: verify_pr
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
           VENDOR_TYPE: ${{ steps.sanity_check_pr_content.outputs.category }}
@@ -161,7 +161,7 @@ jobs:
           cd ..
 
       - name: Delete Namespace
-        if: steps.install-oc.outputs.oc-installed == 'true'
+        if: ${{ steps.install-oc.outputs.oc-installed == 'true' }}
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
         run: |
@@ -170,19 +170,19 @@ jobs:
           ve1/bin/sa-for-chart-testing --delete chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }}
 
       - name: Save PR artifact
-        if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ always() && steps.check_ci_changes.outputs.run-tests != 'true' }}
         run: |
           ve1/bin/pr-artifact --directory=./pr --pr-number=${{ github.event.number }} --api-url=${{ github.event.pull_request._links.self.href }}
 
       - name: Prepare PR comment
-        if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ always() && steps.check_ci_changes.outputs.run-tests != 'true' }}
         env:
           SANITY_ERROR_MESSAGE: ${{ steps.sanity_check_pr_content.outputs.sanity-error-message }}
         run: |
           python3 scripts/prepare_pr_comment.py ${{ steps.sanity_check_pr_content.outcome }} ${{ steps.verify_pr.conclusion }} ${{ github.repository }}
 
       - name: Comment on PR
-        if: always() && steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ always() && steps.check_ci_changes.outputs.run-tests != 'true' }}
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -232,24 +232,24 @@ jobs:
           MERGE_LABELS: ""
 
       - name: Check for PR merge
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         run: |
           ./ve1/bin/check-auto-merge --api-url=${{ github.event.pull_request._links.self.href }}
 
       - name: Block until there is no running workflow
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         uses: softprops/turnstyle@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Release Charts
-        if: steps.check_ci_changes.outputs.run-tests != 'true'
+        if: ${{ steps.check_ci_changes.outputs.run-tests != 'true' }}
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,37 +2,35 @@ name: Test Workflow
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       dry-run:
-        description: 'Run tests but do not create issues {true,false}'
+        description: "Run tests but do not create issues {true,false}"
         required: true
-        default: 'true'
-      notify-id:
-        description: 'Issue notification {github id}'
-        required: false
-        default: ''
+        default: "true"
       vendor-type:
-        description: 'Vendor type {all,partner,redhat,community}'
+        description: "Vendor type {all,partner,redhat,community}"
         required: true
-        default: 'all'
+        default: "all"
       software-name:
-        description: 'Software Name'
+        description: "Software Name"
         required: true
       software-version:
-        description: 'Software Version'
+        description: "Software Version"
         required: true
-
+      notify-id:
+        description: "(Optional) Issue notification {github id}"
+        required: false
+        default: ""
 
 jobs:
   workflow-test:
     name: Workflow Test
     runs-on: ubuntu-20.04
-    if: github.event.pull_request.draft == false
-
+    if: |
+      github.event.pull_request.draft == false
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -44,7 +42,7 @@ jobs:
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Set up Python 3.x Part 2
         run: |
@@ -57,7 +55,7 @@ jobs:
         id: check_request
         run: |
           # check if workflow testing should run.
-          echo "Request type: $GITHUB_EVENT_NAME"
+          echo "Request type: '$GITHUB_EVENT_NAME'"
           if [ "$GITHUB_EVENT_NAME" == "pull_request_target" ]; then
               echo "[INFO] check if PR contains only workflow changes and user is authorized"
               ve1/bin/check-pr-for-ci --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
@@ -68,16 +66,27 @@ jobs:
 
       - name: Check Request Result
         id: check_request_result
-        if: ${{ steps.check_request.outputs.workflow-only-but-not-authorized == 'true'}}
+        if: |
+          steps.check_request.outputs.workflow-only-but-not-authorized == 'true'
         run: |
           # workflow only change but user not authorized
           exit 1
 
-      - name: Test CI Workflow
-        id: test_ci_workflow
-        if: ${{ steps.check_request.outputs.run-tests == 'true'}}
+      - name: (PR) Test CI Workflow
+        if: |
+          github.event_name == 'pull_request_target' && steps.check_request.outputs.run-tests == 'true'
         env:
-          CLUSTER_TOKEN: ${{ secrets.CLUSTER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_NAME: ${{ secrets.BOT_NAME }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          PR_BODY: "Test triggered by ${{ github.event.pull_request.html_url }}."
+        run: |
+          ve1/bin/pytest tests/ --log-cli-level=WARNING --ignore=tests/functional/test_submitted_charts.py
+
+      - name: (Manual) Test CI Workflow
+        if: |
+          github.event_name == 'workflow_dispatch' && steps.check_request.outputs.run-tests == 'true'
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry-run }}
           VENDOR_TYPE: ${{ github.event.inputs.vendor-type }}
@@ -86,15 +95,11 @@ jobs:
           SOFTWARE_VERSION: ${{ github.event.inputs.software-version }}
           BOT_NAME: ${{ secrets.BOT_NAME }}
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          PR_BODY: "Triggerd by ${{ github.event.sender.html_url }} from ${{ github.event.repository.html_url }} on `${{ github.event.ref }}`."
         run: |
-          # Run the wokflow tests
-          if [ "$GITHUB_EVENT_NAME" == "pull_request_target" ]; then
-              ve1/bin/pytest tests/ --log-cli-level=WARNING --ignore=tests/functional/test_submitted_charts.py
-          else
-              echo "[INFO] Dry run ${{ env.DRY_RUN }}"
-              echo "[INFO] Vendor type ${{ env.VENDOR_TYPE }}"
-              echo "[INFO] Notify ID ${{ env.NOTIFY_ID }}"
-              echo "[INFO] Software Name ${{ env.SOFTWARE_NAME }}"
-              echo "[INFO] Software Version ${{ env.SOFTWARE_VERSION }}"
-              ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING
-          fi
+          echo "[INFO] Dry run '${{ env.DRY_RUN }}'"
+          echo "[INFO] Vendor type '${{ env.VENDOR_TYPE }}'"
+          echo "[INFO] Notify ID '${{ env.NOTIFY_ID }}'"
+          echo "[INFO] Software Name '${{ env.SOFTWARE_NAME }}'"
+          echo "[INFO] Software Version '${{ env.SOFTWARE_VERSION }}'"
+          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING

--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -256,7 +256,7 @@ def the_user_has_created_a_error_free_chart_src_with_report(secrets):
 def the_user_sends_the_pull_request(secrets):
     """The user sends the pull request with the chart source files."""
     data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
-            'title': secrets.pr_branch}
+            'title': secrets.pr_branch, 'body': os.environ.get('PR_BODY')}
 
     logger.info(
         f"Create PR with chart source files from '{secrets.test_repo}:{secrets.pr_branch}'")

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -246,7 +246,7 @@ def the_user_has_created_a_error_free_chart_src(secrets):
 def the_user_sends_the_pull_request_with_the_chart_src(secrets):
     """The user sends the pull request with the chart source files."""
     data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
-            'title': secrets.pr_branch}
+            'title': secrets.pr_branch, 'body': os.environ.get('PR_BODY')}
 
     logger.info(
         f"Create PR with chart source files from '{secrets.test_repo}:{secrets.pr_branch}'")

--- a/tests/functional/test_chart_tar_with_report.py
+++ b/tests/functional/test_chart_tar_with_report.py
@@ -257,7 +257,7 @@ def the_user_has_created_a_error_free_chart_tar_with_report(secrets):
 def the_user_sends_the_pull_request(secrets):
     """The user sends the pull request with the chart tar files."""
     data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
-            'title': secrets.pr_branch}
+            'title': secrets.pr_branch, 'body': os.environ.get('PR_BODY')}
 
     logger.info(
         f"Create PR with chart tar files from '{secrets.test_repo}:{secrets.pr_branch}'")

--- a/tests/functional/test_chart_tar_without_report.py
+++ b/tests/functional/test_chart_tar_without_report.py
@@ -248,7 +248,7 @@ def the_user_has_created_a_error_free_chart_tar(secrets):
 def the_user_sends_the_pull_request_with_the_chart_tar(secrets):
     """The user sends the pull request with the chart tar file."""
     data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
-            'title': secrets.pr_branch}
+            'title': secrets.pr_branch, 'body': os.environ.get('PR_BODY')}
 
     logger.info(
         f"Create PR with chart tar file from '{secrets.test_repo}:{secrets.pr_branch}'")

--- a/tests/functional/test_report_only_no_errors.py
+++ b/tests/functional/test_report_only_no_errors.py
@@ -248,7 +248,7 @@ def the_user_has_created_a_report_without_errors(secrets):
 def the_user_sends_the_pull_request_with_the_report(secrets):
     """The user sends the pull request with the report."""
     data = {'head': secrets.pr_branch, 'base': secrets.base_branch,
-            'title': secrets.pr_branch}
+            'title': secrets.pr_branch, 'body': os.environ.get('PR_BODY')}
 
     logger.info(
         f"Create PR with report from '{secrets.test_repo}:{secrets.pr_branch}'")

--- a/tests/functional/test_submitted_charts.py
+++ b/tests/functional/test_submitted_charts.py
@@ -326,7 +326,7 @@ def submission_tests_run_for_submitted_charts(secrets):
 
             # Create PR from test_repo:pr_branch to test_repo:base_branch
             data = {'head': pr_branch, 'base': base_branch,
-                    'title': pr_branch}
+                    'title': pr_branch, 'body': os.environ.get('PR_BODY')}
 
             logger.info(
                 f"Create PR with chart files from '{secrets.test_repo}:{pr_branch}' to '{secrets.test_repo}:{base_branch}'")


### PR DESCRIPTION
This adds a message in the test PR body indicates which PR triggered the test: https://github.com/openshift-helm-charts/sandbox/pull/275#issue-709658161

For manual testing, add a message body stating who and where the test was triggered: https://github.com/openshift-helm-charts/sandbox/pull/278#issue-709690472

Also remove the `edited` trigger to avoid re-run tests on PR title/body changes. Though `edited` will trigger on base branch change but that can be achieved by `synchronized` event on rebasing commit.

Signed-off-by: Allen Bai <abai@redhat.com>