### PR TITLE
workflow: make test releases have unique tags and names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,22 @@ jobs:
           echo "The PR is workflow changes only - do not continue."
           exit 0
 
+      - name: Add 'test' label to PR
+        if: |
+          steps.check_ci_changes.outputs.run-tests != 'true' &&
+          github.event.pull_request.user.login == 'openshift-helm-charts-bot'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = ${{ github.event.number }};
+            github.issues.addLabels({
+                issue_number: Number(issue_number),
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['test']
+            })
+
       - name: Sanity Check PR Content
         id: sanity_check_pr_content
         if: steps.check_ci_changes.outputs.run-tests != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
           exit 0
 
       - name: Add 'test' label to PR
+        id: set_test_label
         if: |
           steps.check_ci_changes.outputs.run-tests != 'true' &&
           github.event.pull_request.user.login == 'openshift-helm-charts-bot'
@@ -59,6 +60,7 @@ jobs:
                 repo: context.repo.repo,
                 labels: ['test']
             })
+            core.setOutput('triggered_by_test', 'true');
 
       - name: Sanity Check PR Content
         id: sanity_check_pr_content
@@ -66,6 +68,8 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_REF: ${{ github.ref }}
+          TRIGGERED_BY_TEST: ${{ steps.set_test_label.outputs.triggered_by_test }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
          INDEX_BRANCH=$(if [ "${GITHUB_REF}" = "refs/heads/main" ]; then echo "refs/heads/gh-pages"; else echo "${GITHUB_REF}-gh-pages"; fi)
           ./ve1/bin/sanity-check-pr --index-branch=${INDEX_BRANCH} --repository=${{ github.repository }} --api-url=${{ github.event.pull_request._links.self.href }}
@@ -272,6 +276,8 @@ jobs:
           CHART_ENTRY_NAME: ${{ steps.sanity_check_pr_content.outputs.chart-entry-name }}
           CHART_NAME_WITH_VERSION: ${{ steps.sanity_check_pr_content.outputs.chart-name-with-version }}
           REDHAT_TO_COMMUNITY: ${{ steps.verify_pr.outputs.redhat_to_community }}
+          TRIGGERED_BY_TEST: ${{ steps.set_test_label.outputs.triggered_by_test }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         id: release-charts
         run: |
           curl -L -o cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v1.2.0/chart-releaser_1.2.0_linux_amd64.tar.gz

--- a/scripts/src/sanitycheckpr/sanitycheckpr.py
+++ b/scripts/src/sanitycheckpr/sanitycheckpr.py
@@ -84,6 +84,10 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
                 sys.exit(1)
 
         tag_name = f"{organization}-{chart}-{version}"
+        if os.environ.get('TRIGGERED_BY_TEST') == 'true':
+            pr_number = os.environ.get("PR_NUMBER")
+            tag_name += f'-test-pr{pr_number}'
+
         print(f"::set-output name=chart-name-with-version::{tag_name}")
         tag_api = f"https://api.github.com/repos/{repository}/git/ref/tags/{tag_name}"
         headers = {'Accept': 'application/vnd.github.v3+json'}

--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -321,7 +321,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -311,7 +311,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_chart_tar_with_report.py
+++ b/tests/functional/test_chart_tar_with_report.py
@@ -322,7 +322,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_chart_tar_without_report.py
+++ b/tests/functional/test_chart_tar_without_report.py
@@ -313,7 +313,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_submitted_charts.py
+++ b/tests/functional/test_submitted_charts.py
@@ -410,7 +410,7 @@ def submission_tests_run_for_submitted_charts(secrets):
             repo.git.branch('-D', f'{base_branch}-gh-pages')
 
             # Check release is published
-            expected_tag = f'{vendor_name}-{chart_name}-{chart_version}'
+            expected_tag = f'{vendor_name}-{chart_name}-{chart_version}-test-pr{pr_number}'
             try:
                 release = get_release_by_tag(secrets, expected_tag)
                 logger.info(f"Released '{expected_tag}' successfully")


### PR DESCRIPTION
This change adds two changes:
 * Add `test` label on PRs generated by bot account for better filtering
 * Use unique tags and names for releases generated by workflow testing so that no race condition on temporary test releases.
 
