### PR TITLE
shorten names used for OCP testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           if [ "${{steps.sanity_check_pr_content.outputs.report-exists}}" != "true" ]; then
             ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
-            ve1/bin/sa-for-chart-testing --create chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }} --token token.txt --server ${API_SERVER}
+            ve1/bin/sa-for-chart-testing --create charts-${{ github.event.number }} --token token.txt --server ${API_SERVER}
           fi
           cd pr-branch
           ../ve1/bin/chart-pr-review --directory=../pr --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
@@ -141,7 +141,7 @@ jobs:
         run: |
           API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
           ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
-          ve1/bin/sa-for-chart-testing --delete chart-verifier-ci-${{ steps.get-repository.outputs.repository }}-${{ github.event.number }}
+          ve1/bin/sa-for-chart-testing --delete charts-${{ github.event.number }}
 
       - name: Save PR artifact
         if: always()


### PR DESCRIPTION
Shortened the default names use for OCP chart testing to allow for long chart names and the 63 character limit for OCP.

Tests result with this change shown here:

infispan community chart : https://github.com/mmulholla/repo/pull/120/checks?check_run_id=3447200650
- got past the host name problem but now hits an issue which looks like a chart problem.

psql chart: https://github.com/mmulholla/repo/runs/3447179400?check_suite_focus=true
- clean report.