### PR TITLE
dotnet/OWNERS: add tmds to owners list

### DIFF
--- a/charts/redhat/redhat/dotnet/OWNERS
+++ b/charts/redhat/redhat/dotnet/OWNERS
@@ -3,7 +3,7 @@ chart:
   shortDescription: This is the Red Hat DotNet chart
 publicPgpKey: null
 users:
-- githubUsername: dperaza4dustbit
+- githubUsername: tmds
 vendor:
   label: redhat
   name: Red Hat


### PR DESCRIPTION
In order to better track the ownership of dotnet chart, add the
owner/author of the chart to OWNERS file.

Ref: https://github.com/redhat-developer/redhat-helm-charts/issues/70
Signed-off-by: Allen Bai <abai@redhat.com>