### PR TITLE
Fix community and redhat path when kubeVersion not set in chart

### DIFF
--- a/scripts/src/chartrepomanager/indexannotations.py
+++ b/scripts/src/chartrepomanager/indexannotations.py
@@ -99,9 +99,9 @@ def getIndexAnnotations(report_path):
 
     if not OCPSupportedSet:
         chart = report_info.get_report_chart(report_path)
-        kubeVersion = chart["kubeVersion"]
         OCPVersions = "N/A"
-        if kubeVersion != "":
+        if "kubeVersion" in chart and chart["kubeVersion"]:
+            kubeVersion = chart["kubeVersion"]
             OCPVersions = getOCPVersions(kubeVersion)
         set_annotations["charts.openshift.io/supportedOpenShiftVersions"] = OCPVersions
 


### PR DESCRIPTION
We are not checking if kubeVersion is in chart before trying to
get the value. This is causing redhat and comunity charts that
do not have kubeVersion set to fail on release step.

Signed-off-by: David Peraza <dperaza@redhat.com>