### PR TITLE
Delete charts/partners/solace/pubsubplus-quickstart directory

### DIFF
--- a/charts/partners/solace/pubsubplus-quickstart/OWNERS
+++ b/charts/partners/solace/pubsubplus-quickstart/OWNERS
@@ -1,8 +1,0 @@
-chart:
-  name: pubsubplus-quickstart
-  shortDescription: unknown
-publicPgpKey: unknown
-users: []
-vendor:
-  label: solace
-  name: Solace Systems


### PR DESCRIPTION
Requested by partner in support case 03124013. Corresponding archived project in Connect is https://connect.redhat.com/projects/61585d5e63810575e4f88e24/overview.
Project in Tech Partner Data Hub: https://connect.redhat.com/internal/technology-partner-data-hub/#/projects/61585d5e63810575e4f88e24