### PR TITLE
Delete charts/partners/ibm/pem-6-2 directory

### DIFF
--- a/charts/partners/ibm/pem-6-2/OWNERS
+++ b/charts/partners/ibm/pem-6-2/OWNERS
@@ -1,8 +1,0 @@
-chart:
-  name: pem-6-2
-  shortDescription: unknown
-publicPgpKey: unknown
-users: []
-vendor:
-  label: ibm
-  name: IBM


### PR DESCRIPTION
Requested by partner IBM rep Nancy Heinz in support case https://access.redhat.com/support/cases/03126380. 
Corresponding project (in Tech Partner Data Hub) https://connect.redhat.com/internal/technology-partner-data-hub/#/projects/6102bef5b094d12384d03ae2 is indeed archived.