### PR TITLE
Adding owners file for the psql service endpoint definition

### DIFF
--- a/charts/redhat/redhat/psql-sed/OWNERS
+++ b/charts/redhat/redhat/psql-sed/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: psql-sed
+  shortDescription: PostgreSQL Service Endpoint Definition
+publicPgpKey: null
+users:
+- githubUsername: dperaza4dustbit
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
Setting myself as owner of this Service Endpoint Definition for
PostgreSQL databases. This SED will be used as a bindable object
that can be used by SBO to project service information to OpenShift
applications.