### PR TITLE
Adding the owner file for MongoDB Service Endpoint Defition(SED) chart

### DIFF
--- a/charts/redhat/redhat/mongo-sed/OWNERS
+++ b/charts/redhat/redhat/mongo-sed/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: mongo-sed
+  shortDescription: MongoDB Service Endpoint Definition
+publicPgpKey: null
+users:
+- githubUsername: fbm3307
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
Setting myself as owner of this Service Endpoint Definition for
MongoDB. This SED will be used as a bindable object
that can be used by SBO to project service information to OpenShift
applications.


Signed-off-by: Feny Mehta <fbm3307@gmail.com>