### PR TITLE
Add owners file for Elasticsearch Service Endpoint Definition

### DIFF
--- a/charts/redhat/redhat/elasticsearch-sed/OWNERS
+++ b/charts/redhat/redhat/elasticsearch-sed/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: elasticsearch-sed
+  shortDescription: Elasticsearch Service Endpoint Definition
+publicPgpKey: null
+users:
+- githubUsername: Kartikey-star
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>
Setting myself as owner of this Service Endpoint Definition for
Elasticsearch. This SED will be used as a bindable object
that can be used by SBO to project service information to OpenShift
applications.