### PR TITLE
Delete OWNERS

### DIFF
--- a/charts/partners/Mavenir/testchart1/OWNERS
+++ b/charts/partners/Mavenir/testchart1/OWNERS
@@ -1,8 +1,0 @@
-chart:
-  name: testchart1
-  shortDescription: unknown
-publicPgpKey: unknown
-users: []
-vendor:
-  label: Mavenir
-  name: Mavenir


### PR DESCRIPTION
An error occurs when closing the repository:

warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:
```
  'charts/partners/Mavenir/testchart1/OWNERS'
  'charts/partners/mavenir/testchart1/OWNERS'
```
and this leaves git with a change which cannot be restored:  
```
changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   charts/partners/mavenir/testchart1/OWNERS
```

To alleviate this I am removing ```charts/partners/Mavenir/testchart1/OWNERS``` which has been confirmed is not required.