### PR TITLE
Add OWNERS for redhat/eap-xp4

### DIFF
--- a/charts/redhat/redhat/eap-xp4/OWNERS
+++ b/charts/redhat/redhat/eap-xp4/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: eap-xp4
+  shortDescription: Build and Deploy EAP XP 4 applications on OpenShift
+publicPgpKey: null
+users:
+  - githubUsername: bstansberry
+  - githubUsername: jmesnil
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
In preparation of the addition of the Helm Chart for EAP XP4, can you add the OWNERS for the `eap-xp4` chart please?

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>