### PR TITLE
Updated OWNERS file to enable release testing on fork

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - jasperchui
 - dperaza4dustbit
 - openshift-helm-charts-bot
+- tisutisu
 
 reviewers:
 - baijum


### PR DESCRIPTION
While testing release 1.4.2 on my fork, it failed here https://github.com/tisutisu/charts/pull/1/checks#step:5:19
This change will enable testing release in my fork. 