### PR TITLE
add provider delivery the new Mavenir OWNERS

### DIFF
--- a/charts/partners/mavenir/ausf/OWNERS
+++ b/charts/partners/mavenir/ausf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: ausf
   shortDescription: Mavenir 5GCore AUSF CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/ksync/OWNERS
+++ b/charts/partners/mavenir/ksync/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: ksync
   shortDescription: Mavenir 5GCore KSYNC CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/nrf/OWNERS
+++ b/charts/partners/mavenir/nrf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: nrf
   shortDescription: Mavenir 5GCore NRF CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/nssf/OWNERS
+++ b/charts/partners/mavenir/nssf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: nssf
   shortDescription: Mavenir 5GCore NSSF CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/pcf/OWNERS
+++ b/charts/partners/mavenir/pcf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: pcf
   shortDescription: Mavenir 5GCore PCF CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/smf/OWNERS
+++ b/charts/partners/mavenir/smf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: smf
   shortDescription: Mavenir 5GCore SMF CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/smsf/OWNERS
+++ b/charts/partners/mavenir/smsf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: smsf
   shortDescription: null
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: kaitaklam
 vendor:

--- a/charts/partners/mavenir/udm/OWNERS
+++ b/charts/partners/mavenir/udm/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: udm
   shortDescription: Mavenir 5GCore UDM CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/udr/OWNERS
+++ b/charts/partners/mavenir/udr/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: udr
   shortDescription: Mavenir 5GCore UDR CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/udsf/OWNERS
+++ b/charts/partners/mavenir/udsf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: udsf
   shortDescription: Mavenir 5GCore UDSF CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:

--- a/charts/partners/mavenir/upf/OWNERS
+++ b/charts/partners/mavenir/upf/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: upf
   shortDescription: Mavenir 5GCore UPF CNF Helm charts
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: k-anirwan
 vendor:


### PR DESCRIPTION
Added provider deliver to Mavenir OWNERS files for these charts:
/ausf
/ksync
/nrf
/nssf
/pcf
/smf
/smsf
/udm
/udr
/udsf
/udf

see: https://connect.redhat.com/support/technology-partner/#/case/03330190