### PR TITLE
Redoing provider delivery flag from nfvri chart

### DIFF
--- a/charts/partners/intracom-telecom/nfvri/OWNERS
+++ b/charts/partners/intracom-telecom/nfvri/OWNERS
@@ -2,6 +2,7 @@ chart:
   name: nfvri
   shortDescription: NFV-RI (TM) Helm Chart Repository
 publicPgpKey: null
+providerDelivery: True
 users:
 - githubUsername: angelouev
 - githubUsername: danielchristod


### PR DESCRIPTION
Needed to redo this flag as mercury-bot overwrote it. Discussing how to avoid this risk long term.