### PR TITLE
Toggle provider delivery in newly created nextevolution  OWNERS files

### DIFF
--- a/charts/partners/nextevolution/nedb-service-engine/OWNERS
+++ b/charts/partners/nextevolution/nedb-service-engine/OWNERS
@@ -1,7 +1,7 @@
 chart:
   name: nedb-service-engine
   shortDescription: unknown
-providerDelivery: true
+providerDelivery: false
 publicPgpKey: unknown
 users: []
 vendor:


### PR DESCRIPTION
Due to a temporary error in OWNER file creation the provider delivery setting was set to true instead of false.