### PR TITLE
Unset provider delivery in yugabytedb OWNERS file

### DIFF
--- a/charts/partners/yugabytedb/yugaware-openshift/OWNERS
+++ b/charts/partners/yugabytedb/yugaware-openshift/OWNERS
@@ -2,7 +2,7 @@ chart:
   name: yugaware-openshift
   shortDescription: 'Use YugabyteDB Anywhere''s orchestration and monitoring to manage
     YugabyteDB universes. '
-providerDelivery: true
+providerDelivery: false
 publicPgpKey: null
 users:
 - githubUsername: baba230896


### PR DESCRIPTION
Provider delivery incorrect set to true due to a bug in OWNER file creation.