### PR TITLE
Toggle provider delivery in newly created vitagroup OWNERS files

### DIFF
--- a/charts/partners/vitagroupag/cdr-core-ehrbase-enterprise/OWNERS
+++ b/charts/partners/vitagroupag/cdr-core-ehrbase-enterprise/OWNERS
@@ -1,7 +1,7 @@
 chart:
   name: cdr-core-ehrbase-enterprise
   shortDescription: null
-providerDelivery: true
+providerDelivery: false
 publicPgpKey: null
 users:
 - githubUsername: bjoernpauli

--- a/charts/partners/vitagroupag/hip-cdr-core/OWNERS
+++ b/charts/partners/vitagroupag/hip-cdr-core/OWNERS
@@ -1,7 +1,7 @@
 chart:
   name: hip-cdr-core
   shortDescription: null
-providerDelivery: true
+providerDelivery: false
 publicPgpKey: null
 users:
 - githubUsername: bjoernpauli


### PR DESCRIPTION
Due to a temporary error in OWNER file creation the provider delivery setting was set to true instead of false.