### PR TITLE
Add owners file for PostgreSQL imagestreams

### DIFF
--- a/charts/redhat/redhat/postgresql-imagestreams/OWNERS
+++ b/charts/redhat/redhat/postgresql-imagestreams/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: postgresql-imagestreams
+  description: The Red Hat PostgreSQL imagestreams
+publicPgpKey: null
+users:
+  - githubUsername: phracek
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
This pull request adds Helm chart for PostgreSQL imagestreams definition.