### PR TITLE
Add OpDev maintainers as owners and reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
+- komish
+- jsm84
+- jomkz
 - baijum
 - mmulholla
 - jasperchui
@@ -10,6 +13,9 @@ approvers:
 - Kartikey-star
 
 reviewers:
+- komish
+- jsm84
+- jomkz
 - baijum
 - mmulholla
 - jasperchui


### PR DESCRIPTION
This adds OpDev maintainers to the project so that we can run workflow updates.