### PR TITLE
Add support for Red Hat mariadb imagestreams

### DIFF
--- a/charts/redhat/redhat/mariadb-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/mariadb-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is expermental, do not use it in production. Provides a Red Hat MariaDB database.
+  For more information about using this database image, including OpenShift considerations,
+  see https://github.com/sclorg/mariadb-container/blob/master/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat MariaDB database service imagestreams (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: mariadb-imagestreams
+tags: database,mariadb
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/mariadb-imagestreams/0.0.1/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/mariadb-imagestreams/0.0.1/src/templates/imagestreams.yaml
@@ -1,0 +1,124 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: mariadb
+  annotations:
+    openshift.io/display-name: MariaDB
+spec:
+  tags:
+    - name: latest
+      annotations:
+        openshift.io/display-name: MariaDB (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MariaDB database on RHEL. For more information about using
+          this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mariadb-container/tree/master/10.5/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of MariaDB available on OpenShift,
+          including major version updates.
+        iconClass: icon-mariadb
+        tags: 'database,mariadb'
+      from:
+        kind: ImageStreamTag
+        name: 10.5-el8
+      referencePolicy:
+        type: Local
+    - name: 10.3-el8
+      annotations:
+        openshift.io/display-name: MariaDB 10.3 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MariaDB 10.3 database on RHEL 8. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.
+        iconClass: icon-mariadb
+        tags: 'database,mariadb'
+        version: '10.3'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/mariadb-103:latest'
+      referencePolicy:
+        type: Local
+    - name: 10.3-el7
+      annotations:
+        openshift.io/display-name: MariaDB 10.3 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MariaDB 10.3 database on RHEL 7. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.
+        iconClass: icon-mariadb
+        tags: 'database,mariadb'
+        version: '10.3'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/mariadb-103-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: '10.3'
+      annotations:
+        openshift.io/display-name: MariaDB 10.3
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MariaDB 10.3 database on RHEL 7. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.
+        iconClass: icon-mariadb
+        tags: 'database,mariadb,hidden'
+        version: '10.3'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/mariadb-103-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: 10.5-el7
+      annotations:
+        openshift.io/display-name: MariaDB 10.5 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MariaDB 10.5 database on RHEL 7. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mariadb-container/tree/master/10.5/README.md.
+        iconClass: icon-mariadb
+        tags: 'database,mariadb'
+        version: '10.5'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/mariadb-105-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: 10.5-el8
+      annotations:
+        openshift.io/display-name: MariaDB 10.5 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MariaDB 10.5 database on RHEL 8. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mariadb-container/tree/master/10.5/README.md.
+        iconClass: icon-mariadb
+        tags: 'database,mariadb'
+        version: '10.5'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/mariadb-105:latest'
+      referencePolicy:
+        type: Local
+    - name: 10.5-el9
+      annotations:
+        openshift.io/display-name: MariaDB 10.5 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MariaDB 10.5 database on RHEL 9. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mariadb-container/tree/master/10.5/README.md.
+        iconClass: icon-mariadb
+        tags: 'database,mariadb'
+        version: '10.5'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/mariadb-105:latest'
+      referencePolicy:
+        type: Local


### PR DESCRIPTION
This Helm chart contains all Red Hat MariaDB imagestreams

Please review it and verify it before merging.

The output from verifier is:

```bash
results:
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'Chart Install failure: unable to build kubernetes objects from release manifest: unknown'
    - check: v1.0/has-readme
      type: Mandatory
      outcome: FAIL
      reason: Chart does not have a README
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: FAIL
      reason: Values schema file does not exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/contains-values
      type: Mandatory
Add support for Red Hat mariadb imagestreams
      outcome: FAIL
      reason: Values file does not exist
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: No images to certify
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/contains-test
      type: Mandatory
      outcome: FAIL
      reason: Chart test files do not exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
```