### PR TITLE
Add support for Red Hat HTTPD imagestreams

### DIFF
--- a/charts/redhat/redhat/httpd-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/httpd-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  This content is expermental, do not use it in production. Red Hat Apache HTTP Server imagestreams.
+  For more information about HTTPD container see https://github.com/sclorg/httpd-container/.
+annotations:
+  charts.openshift.io/name: Red Hat Apache HTTP Server imagestreams (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: httpd-imagestreams
+tags: builder,httpd
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/httpd-imagestreams/0.0.1/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/httpd-imagestreams/0.0.1/src/templates/imagestreams.yaml
@@ -1,0 +1,126 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Apache HTTP Server (httpd)
+  name: httpd
+spec:
+  tags:
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) on RHEL.
+          For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of Httpd available on OpenShift,
+          including major version updates.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+      from:
+        kind: ImageStreamTag
+        name: 2.4-ubi8
+      referencePolicy:
+        type: Local
+      name: latest
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          UBI 9. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (UBI 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi9/httpd-24:latest'
+      referencePolicy:
+        type: Local
+      name: 2.4-ubi9
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 8. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (UBI 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi8/httpd-24:latest'
+      referencePolicy:
+        type: Local
+      name: 2.4-ubi8
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 8. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd,hidden'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/rhel8/httpd-24
+      referencePolicy:
+        type: Local
+      name: 2.4-el8
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 7. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/rhscl/httpd-24-rhel7
+      referencePolicy:
+        type: Local
+      name: 2.4-el7
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 7. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd,hidden'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/rhscl/httpd-24-rhel7
+      referencePolicy:
+        type: Local
+      name: '2.4'


### PR DESCRIPTION
This Helm chart contains all Red Hat HTTPD imagestreams

Please review it and verify it before merging.

The output from verifier is:

```bash
results:
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/has-readme
      type: Mandatory
      outcome: FAIL
      reason: Chart does not have a README
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/contains-test
      type: Mandatory
      outcome: FAIL
      reason: Chart test files do not exist
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'Chart Install failure: unable to build kubernetes objects from release manifest: unknown'
    - check: v1.0/contains-values
      type: Mandatory
      outcome: FAIL
      reason: Values file does not exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: No images to certify
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: FAIL
      reason: Values schema file does not exist
```

The HTTPD Helm Chart imagestreams are tested by our internal test suite here: https://github.com/sclorg/helm-charts/pull/22