### PR TITLE
Add support for RedHat redis imagestreams

### DIFF
--- a/charts/redhat/redhat/redis-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redis-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  This content is expermental, do not use it in production. Provides a Redis database on RHEL imagestreams.
+  For more information about Redis container see https://github.com/sclorg/redis-container/.
+annotations:
+  charts.openshift.io/name: Provides a Redis database on RHEL imagestreams (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: redis-imagestreams
+tags: builder,redis
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redis-imagestreams/0.0.1/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redis-imagestreams/0.0.1/src/templates/imagestreams.yaml
@@ -1,0 +1,76 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Redis
+  name: redis
+spec:
+  tags:
+    - annotations:
+        description: >-
+          Provides a Redis database on RHEL. For more information about using
+          this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of Redis available on OpenShift,
+          including major version updates.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+      from:
+        kind: ImageStreamTag
+        name: 6-el8
+      referencePolicy:
+        type: Local
+      name: latest
+    - annotations:
+        description: >-
+          Provides a Redis 6 database on RHEL 9. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis 6 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+        version: '6'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/redis-6:latest'
+      referencePolicy:
+        type: Local
+      name: 6-el9
+    - annotations:
+        description: >-
+          Provides a Redis 6 database on RHEL 8. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis 6 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+        version: '6'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/redis-6:latest'
+      referencePolicy:
+        type: Local
+      name: 6-el8
+    - annotations:
+        description: >-
+          Provides a Redis 6 database on RHEL 7. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis 6 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+        version: '6'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/redis-6-rhel7:latest'
+      referencePolicy:
+        type: Local
+      name: 6-el7


### PR DESCRIPTION
This Helm chart contains all Red Hat Redis imagestreams

Please review it and verify it before merging.

The output from verifier is:
```bash
results:
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: FAIL
      reason: Values schema file does not exist
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'Chart Install failure: unable to build kubernetes objects from release manifest: unknown'
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/contains-values
      type: Mandatory
      outcome: FAIL
      reason: Values file does not exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/has-readme
      type: Mandatory
      outcome: FAIL
      reason: Chart does not have a README
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: No images to certify
    - check: v1.0/contains-test
      type: Mandatory
      outcome: FAIL
      reason: Chart test files do not exist

```

This Helm chart was already tested against OpenShift 4 bythis pull request https://github.com/sclorg/helm-charts/pull/25