### PR TITLE
Add support for Red Hat mysql imagestreams

### DIFF
--- a/charts/redhat/redhat/mysql-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/mysql-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is expermental, do not use it in production. Provides a MySQL 8.0 database.
+  For more information about using this database image, including OpenShift considerations,
+  see https://github.com/sclorg/mysql-container/blob/master/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat MySQL database service imagestreams (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: mysql-imagestreams
+tags: database,mysql
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/mysql-imagestreams/0.0.1/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/mysql-imagestreams/0.0.1/src/templates/imagestreams.yaml
@@ -1,0 +1,92 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: mysql
+  annotations:
+    openshift.io/display-name: MySQL
+spec:
+  tags:
+    - name: latest
+      annotations:
+        openshift.io/display-name: MySQL (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MySQL database on RHEL. For more information about using
+          this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mysql-container/blob/master/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of MySQL available on OpenShift,
+          including major version updates.
+        iconClass: icon-mysql-database
+        tags: mysql
+      from:
+        kind: ImageStreamTag
+        name: 8.0-el8
+      referencePolicy:
+        type: Local
+    - name: 8.0-el9
+      annotations:
+        openshift.io/display-name: MySQL 8.0 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MySQL 8.0 database on RHEL 9. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mysql-container/blob/master/README.md.
+        iconClass: icon-mysql-database
+        tags: mysql
+        version: '8.0'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/mysql-80:latest'
+      referencePolicy:
+        type: Local
+    - name: 8.0-el8
+      annotations:
+        openshift.io/display-name: MySQL 8.0 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MySQL 8.0 database on RHEL 8. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mysql-container/blob/master/README.md.
+        iconClass: icon-mysql-database
+        tags: mysql
+        version: '8.0'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/mysql-80:latest'
+      referencePolicy:
+        type: Local
+    - name: 8.0-el7
+      annotations:
+        openshift.io/display-name: MySQL 8.0 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MySQL 8.0 database on RHEL 7. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mysql-container/blob/master/README.md.
+        iconClass: icon-mysql-database
+        tags: mysql
+        version: '8.0'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/mysql-80-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: '8.0'
+      annotations:
+        openshift.io/display-name: MySQL 8.0
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a MySQL 8.0 database on RHEL 7. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/mysql-container/blob/master/README.md.
+        iconClass: icon-mysql-database
+        tags: 'mysql,hidden'
+        version: '8.0'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/mysql-80-rhel7:latest'
+      referencePolicy:
+        type: Local


### PR DESCRIPTION
This Helm chart contains all Red Hat MariaDB imagestreams

Please review it and verify it before merging.

The output from verifier is:

```bash
results:
    - check: v1.0/has-readme
      type: Mandatory
      outcome: FAIL
      reason: Chart does not have a README
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: FAIL
      reason: Values schema file does not exist
    - check: v1.0/contains-values
      type: Mandatory
      outcome: FAIL
      reason: Values file does not exist
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'Chart Install failure: unable to build kubernetes objects from release manifest: unknown'
    - check: v1.0/contains-test
      type: Mandatory
      outcome: FAIL
      reason: Chart test files do not exist
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: No images to certify
```

The Helm chart was tested against OpenShift 4 by this pull request: https://github.com/sclorg/helm-charts/pull/20