### PR TITLE
Add nginx-imagestreams Helm Chart

### DIFF
--- a/charts/redhat/redhat/nginx-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/nginx-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  This content is expermental, do not use it in production. Build and serve static content via Nginx HTTP server
+  and a reverse proxy (nginx) on RHEL. https://github.com/sclorg/nginx-container/blob/master/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Nginx HTTP server and a reverse proxy (nginx) (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: nginx-imagestreams
+tags: builder,nginx
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/nginx-imagestreams/0.0.1/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/nginx-imagestreams/0.0.1/src/templates/imagestreams.yaml
@@ -1,0 +1,88 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Nginx HTTP server and a reverse proxy (nginx)
+  name: nginx
+spec:
+  tags:
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of Nginx available on OpenShift,
+          including major version updates.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+      from:
+        kind: ImageStreamTag
+        name: 1.20-ubi8
+      referencePolicy:
+        type: Local
+      name: latest
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 8. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.20 (UBI 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.20'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi9/nginx-120:latest'
+      referencePolicy:
+        type: Local
+      name: 1.20-ubi9
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 8. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.20 (UBI 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.20'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi8/nginx-120:latest'
+      referencePolicy:
+        type: Local
+      name: 1.20-ubi8
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 7. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.20 (UBI 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.20'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi7/nginx-120:latest'
+      referencePolicy:
+        type: Local
+      name: 1.20-ubi7


### PR DESCRIPTION
This Helm chart contains all Red Hat Nginx imagestreams

Please review it and verify it before merging.

