### PR TITLE
OWNERS file for MariaDB persistent storage Helm chart

### DIFF
--- a/charts/redhat/redhat/mariadb-persistent/OWNERS
+++ b/charts/redhat/redhat/mariadb-persistent/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: mariadb-persistent
+  description: This is the Red Hat MariaDB persistent storage
+publicPgpKey: null
+users:
+  - githubUsername: phracek
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
This pull request adds `OWNERS` file for MariaDB persistent storage Helm Chart.