### PR TITLE
chore: relocate community chart for backstage under janus-idp vendor

### DIFF
--- a/charts/community/janus-idp/backstage/OWNERS
+++ b/charts/community/janus-idp/backstage/OWNERS
@@ -4,6 +4,7 @@ chart:
 publicPgpKey: null
 users:
   - githubUsername: sabre1041
+  - githubUsername: tumido
 vendor:
-  label: redhat
-  name: Backstage
+  label: janus-idp
+  name: Janus IDP


### PR DESCRIPTION
This PR prepares grounds for our retry on https://github.com/openshift-helm-charts/charts/pull/599

We have a brand new chart https://github.com/janus-idp/helm-backstage that we'd like to introduce into the catalog here in an upcomming PR.

After consulting with @sabre1041 we've decided to relocate the chart from `charts/community/redhat/backstage` to `charts/community/janus-idp/backstage` to prevent user confusion. In future, we aim to introduce a certified chart with Red Hat as the vendor to `charts/redhat`, so having both associated with Red Hat instead of labeling the community version as provided by Janus IDP community may cause confusion.

I've also taken the liberty to add myself to the maintainer list in the charts `OWNERS` file. Not sure if there's any formal application process required. If I've missed any steps, please tell me. 