### PR TITLE
Add MySQL persistent helm chart

### DIFF
--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  This content is expermental, do not use it in production. MySQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.
+
+  NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
+name: mysql-persistent
+tags: database,mysql
+version: 0.0.1
+annotations:
+  charts.openshift.io/name: Red Hat MySQL database service, with persistent storage (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/README.md
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/README.md
@@ -1,0 +1,22 @@
+# MySQL helm chart
+
+A Helm chart for building and deploying a [MySQL](https://github/sclorg/mysql-container) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                                       | Description | Default | Additional Information |
+|---------------------------------------------| ----------- | -- | ---------------------- |
+| `database_service_name`                     | The name of the OpenShift Service exposed for the database. | `mysql` | - |
+| `mysql_user`                                | Username for MySQL user that will be used for accessing the database. | `testu` | Expresion like: `user[A-Z0-9]{3}` |
+| `mysql_root_password`                       | Password for the MySQL root user. | `testur` | Expression like: `[a-zA-Z0-9]{16}` |
+| `mysql_database`                            | Name of the MySQL database accessed. | `testdb` |  |
+| `mysql_password`                            | Password for the MySQL connection user. | `testp` | Expression like: `[a-zA-Z0-9]{16}` |
+| `mysql_version`                             | Version of MySQL image to be used (8.0-el8, or latest). | `8.0-el8` |  |
+| `namespace`                                 | The OpenShift Namespace where the ImageStream resides. | `mysql-persistent-testing` | |
+| `memory_limit`                              | Maximum amount of memory the container can use. | `521Mi` |  |
+| `volume_capacity`                           | Volume space available for data, e.g. 512Mi, 2Gi. | `1Gi` |  |

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/deploymentconfig.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/deploymentconfig.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    template: mysql-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  replicas: 1
+  selector:
+    name: {{ .Values.database_service_name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.database_service_name }}
+    spec:
+      containers:
+      - env:
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              key: database-user
+              name: {{ .Values.database_service_name }}
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-password
+              name: {{ .Values.database_service_name }}
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-root-password
+              name: {{ .Values.database_service_name }}
+        - name: MYSQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database-name
+              name: {{ .Values.database_service_name }}
+        image: ' '
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - MYSQL_PWD="$MYSQL_PASSWORD" mysqladmin -u $MYSQL_USER ping
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        name: mysql
+        ports:
+        - containerPort: 3306
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - MYSQL_PWD="$MYSQL_PASSWORD" mysqladmin -u $MYSQL_USER ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}
+        volumeMounts:
+        - mountPath: /var/lib/mysql/data
+          name: {{ .Values.database_service_name }}-data
+      volumes:
+      - name: {{ .Values.database_service_name }}-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.database_service_name }}
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - mysql
+      from:
+        kind: ImageStreamTag
+        name: mysql:{{ .Values.mysql_version }}
+    type: ImageChange
+  - type: ConfigChange

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/deploymentconfig.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/deploymentconfig.yaml
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: database-name
               name: {{ .Values.database_service_name }}
-        image: ' '
+        image: "mysql:{{ .Values.mysql_version }}"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -80,5 +80,6 @@ spec:
       from:
         kind: ImageStreamTag
         name: mysql:{{ .Values.mysql_version }}
+        namespace: {{ .Values.namespace }}
     type: ImageChange
   - type: ConfigChange

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/persistentvolumeclaim.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    template: mysql-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volume_capacity }}

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/secret.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+    template.openshift.io/expose-password: '{.data[''database-password'']}'
+    template.openshift.io/expose-root_password: '{.data[''database-root-password'']}'
+    template.openshift.io/expose-username: '{.data[''database-user'']}'
+  labels:
+    template: mysql-persistent-template
+  name: {{ .Values.database_service_name }}
+stringData:
+  database-name: {{ .Values.mysql_database }}
+  database-password: {{ .Values.mysql_password }}
+  database-root-password: {{ .Values.mysql_root_password }}
+  database-user: {{ .Values.mysql_user }}

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    template.openshift.io/expose-uri: mysql://{.spec.clusterIP}:{.spec.ports[?(.name=="mysql")].port}
+  labels:
+    template: mysql-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  ports:
+  - name: mysql
+    port: 3306
+  selector:
+    name: {{ .Values.database_service_name }}

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/tests/test-mysql-connection.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/templates/tests/test-mysql-connection.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.database_service_name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "mysql-connection-test"
+      image: "registry.redhat.io/rhel8/mysql-80:latest"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: MARIADB_USER
+          value: "{{ .Values.mysql_user }}"
+        - name: MARIADB_PASSWORD
+          value: "{{ .Values.mysql_password }}"
+        - name: MARIADB_DATABASE
+          value: "{{ .Values.mysql_database }}"
+      command:
+        - /bin/bash
+        - -ec
+        - "echo \"SELECT 42 as testval\\g\" | mysql --connect-timeout=15 -h {{ .Values.database_service_name }} $MARIADB_DATABASE -u$MARIADB_USER -p$MARIADB_PASSWORD"
+  restartPolicy: Never

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/values.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "database_service_name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "mysql_database": {
+            "type": "string"
+        },
+        "mysql_password": {
+            "type": "string"
+        },
+        "mysql_root_password": {
+            "type": "string"
+        },
+        "mysql_user": {
+            "type": "string"
+        },
+        "volume_capacity": {
+            "type": "string",
+            "title": "Persistent Volume Size",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 1,
+            "sliderMax": 100,
+            "sliderUnit": "Gi"
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Database memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "mysql_version": {
+            "type": "string",
+            "description": "Specify mysql imagestream tag",
+            "enum": [ "latest", "8.0-el9", "8.0-el8", "8.0-el7" ]
+        }
+    }
+}
+

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/values.yaml
@@ -1,0 +1,9 @@
+database_service_name: mysql
+memory_limit: 512Mi
+mysql_database: testdb
+mysql_password: testp # TODO: must define a default value for .mysql_password'
+mysql_root_password: testur # TODO: must define a default value for .mysql_root_password'
+mysql_user: testu # TODO: must define a default value for .mysql_user'
+mysql_version: 8.0-el8
+namespace: mysql-persistent-testing
+volume_capacity: 1Gi

--- a/charts/redhat/redhat/mysql-persistent/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/mysql-persistent/0.0.1/src/values.yaml
@@ -5,5 +5,5 @@ mysql_password: testp # TODO: must define a default value for .mysql_password'
 mysql_root_password: testur # TODO: must define a default value for .mysql_root_password'
 mysql_user: testu # TODO: must define a default value for .mysql_user'
 mysql_version: 8.0-el8
-namespace: mysql-persistent-testing
+namespace: openshift
 volume_capacity: 1Gi


### PR DESCRIPTION
This pull request adds mysql persistent storage Helm Chart

Mysql Helm chart was tested in OpenShift 4 environment here: https://github.com/sclorg/helm-charts/pull/30

and results are:

```bash
test_mysql_imagestreams.py::TestHelmMySQLImageStreams::test_package_imagestream[8.0-el9-registry.redhat.io/rhel9/mysql-80:latest] [32mPASSED[0m[32m [ 25%][0m
test_mysql_imagestreams.py::TestHelmMySQLImageStreams::test_package_imagestream[8.0-el8-registry.redhat.io/rhel8/mysql-80:latest] [32mPASSED[0m[32m [ 50%][0m
test_mysql_imagestreams.py::TestHelmMySQLImageStreams::test_package_imagestream[8.0-el7-registry.redhat.io/rhscl/mysql-80-rhel7:latest] [32mPASSED[0m[32m [ 75%][0m
test_mysql_template.py::TestHelmMySQLDBPersistent::test_package_persistent [32mPASSED[0m[32m [100%][0m
```