### PR TITLE
Add redis Helm Chart persistent template

### DIFF
--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  This content is expermental, do not use it in production. Redis in-memory data structure store, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.
+
+  NOTE: You must have persistent volumes available in your cluster to use this template.
+name: redis-persistent
+tags: database,redis
+version: 0.0.1
+annotations:
+  charts.openshift.io/name: Red Hat Redis in-memory data structure store, with persistent storage (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/README.md
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/README.md
@@ -1,0 +1,19 @@
+# Redis helm chart
+
+A Helm chart for building and deploying a [Redis](https://github/sclorg/redis-container) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                                       | Description | Default | Additional Information |
+|---------------------------------------------| ----------- | -- | ---------------------- |
+| `database_service_name`                     | The name of the OpenShift Service exposed for the database. | `redis` | - |
+| `redis_password`                            | Password for the Redis connection user. |  | Expression like: `[a-zA-Z0-9]{16}` |
+| `redis_version`                             | Version of Redis image to be used (6-el8, or latest). | `6-el8` |  |
+| `namespace`                                 | The OpenShift Namespace where the ImageStream resides. | `redis-persistent-testing` | |
+| `memory_limit`                              | Maximum amount of memory the container can use. | `521Mi` |  |
+| `volume_capacity`                           | Volume space available for data, e.g. 512Mi, 2Gi. | `1Gi` |  |

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/deploymentconfig.yaml
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/deploymentconfig.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    template: redis-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  replicas: 1
+  selector:
+    name: {{ .Values.database_service_name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.database_service_name }}
+    spec:
+      containers:
+      - env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-password
+              name: {{ .Values.database_service_name }}
+        image: "redis:{{ .Values.redis_version }}"
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: 6379
+          timeoutSeconds: 1
+        name: redis
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - test "$(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping)" == "PONG"
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}
+        securityContext:
+          capabilities: {}
+          privileged: false
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /var/lib/redis/data
+          name: {{ .Values.database_service_name }}-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - name: {{ .Values.database_service_name }}-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.database_service_name }}
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - redis
+      from:
+        kind: ImageStreamTag
+        name: redis:{{ .Values.redis_version }}
+      lastTriggeredImage: ""
+    type: ImageChange
+  - type: ConfigChange
+status: {}

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/persistentvolumeclaim.yaml
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    template: redis-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volume_capacity }}

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/secret.yaml
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    template.openshift.io/expose-password: '{.data[''database-password'']}'
+  labels:
+    template: redis-persistent-template
+  name: {{ .Values.database_service_name }}
+stringData:
+  database-password: {{ .Values.redis_password }}

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    template.openshift.io/expose-uri: redis://{.spec.clusterIP}:{.spec.ports[?(.name=="redis")].port}
+  labels:
+    template: redis-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  ports:
+  - name: redis
+    nodePort: 0
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    name: {{ .Values.database_service_name }}
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/tests/test-redis-connection.yaml
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/templates/tests/test-redis-connection.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.database_service_name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "redis-connection-test"
+      image: "registry.redhat.io/rhel8/redis-6:latest"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: REDIS_PASSWORD
+          value: "{{ .Values.redis_password }}"
+      command:
+        - /bin/bash
+        - -ec
+        - "timeout 15 redis-cli -h {{ .Values.database_service_name }} -a $REDIS_PASSWORD ping"
+  restartPolicy: Never

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/values.schema.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "database_service_name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "redis_password": {
+            "type": "string"
+        },
+        "volume_capacity": {
+            "type": "string",
+            "title": "Persistent Volume Size",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 1,
+            "sliderMax": 100,
+            "sliderUnit": "Gi"
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Database memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "redis_version": {
+            "type": "string",
+            "description": "Specify redis imagestream tag",
+            "enum": [ "latest", "6-el9", "6-el8", "6-el7" ]
+        }
+    }
+}
+

--- a/charts/redhat/redhat/redis-persistent/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/redis-persistent/0.0.1/src/values.yaml
@@ -1,0 +1,6 @@
+database_service_name: redis
+memory_limit: 512Mi
+namespace: redis-persistent-testing
+redis_password: testp # TODO: must define a default value for .redis_password'
+redis_version: 6-el8
+volume_capacity: 1Gi


### PR DESCRIPTION
This pull request adds redis persistent storage Helm Chart

Redis Helm chart was tested in OpenShift 4 environment here: https://github.com/sclorg/helm-charts/pull/31

and results are:

```bash
test_redis_imagestreams.py::TestHelmRedisImageStreams::test_package_imagestream[6-el9-registry.redhat.io/rhel9/redis-6:latest] [32mPASSED[0m[32m [ 25%][0m
test_redis_imagestreams.py::TestHelmRedisImageStreams::test_package_imagestream[6-el7-registry.redhat.io/rhscl/redis-6-rhel7:latest] [32mPASSED[0m[32m [ 50%][0m
test_redis_imagestreams.py::TestHelmRedisImageStreams::test_package_imagestream[6-el8-registry.redhat.io/rhel8/redis-6:latest] [32mPASSED[0m[32m [ 75%][0m
test_redis_template.py::TestHelmRedisPersistent::test_package_persistent [32mPASSED[0m[32m [100%][0m

```