### PR TITLE
Add OWNERS file for httpd template chart

### DIFF
--- a/charts/redhat/redhat/httpd-template/OWNERS
+++ b/charts/redhat/redhat/httpd-template/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: httpd-template
+  description: This is the Red Hat Apache HTTP Server template chart
+publicPgpKey: null
+users:
+  - githubUsername: phracek
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
This pull request adds OWNERS file for Red Hat Apache web server template chart and fixes OWNERS file for httpd-imagestreams chart.