### PR TITLE
Add missing charts.openshift.io/name for eap74 1.1.2

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3682,6 +3682,7 @@ entries:
       charts.openshift.io/submissionTimestamp: '2023-06-14T15:41:08.067608+00:00'
       charts.openshift.io/supportedOpenShiftVersions: '>=4.6'
       charts.openshift.io/testedOpenShiftVersion: '4.12'
+      charts.openshift.io/name: JBoss EAP 7.4
     apiVersion: v2
     appVersion: '7.4'
     dependencies:


### PR DESCRIPTION
This does not fix #894 but adds back the annotation that was removed when the index.yaml was updated.