### PR TITLE
Add Red Hat NodeJS imagestream chart

### DIFF
--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is expermental, do not use it in production. Build and run NodeJS applications on UBI.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat PHP applications on UBI (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: redhat-nodejs-imagestreams
+tags: builder,nodejs
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.1/src/templates/nodejs-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.1/src/templates/nodejs-imagestream.yaml
@@ -1,0 +1,103 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: nodejs
+  annotations:
+    openshift.io/display-name: Node.js
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Node.js (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      supports: nodejs
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 16-ubi8
+    referencePolicy:
+      type: Local
+  - name: 16-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-16:latest
+    referencePolicy:
+      type: Local
+  - name: 16-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-16-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 16-ubi8
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-16:latest
+    referencePolicy:
+      type: Local
+  - name: 16-ubi8-minimal
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 8 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 8 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-16-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 14-ubi7
+    annotations:
+      openshift.io/display-name: Node.js 14 (UBI 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 14 applications on UBI 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs,hidden
+      version: '14'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi7/nodejs-14:latest
+    referencePolicy:
+      type: Local


### PR DESCRIPTION
This pull request add Red Hat NodeJS imagestream chart.

The chart is also named as redhat-nodejs-imagestream in Chart.yaml file.