### PR TITLE
Fix redhat-nodejs-imagestream so they are certified

### DIFF
--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/Chart.yaml
@@ -1,0 +1,16 @@
+description: |-
+  This content is experimental, do not use it in production. Build and run NodeJS applications on UBI.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat NodeJS imagestreams (experimental).
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.2
+kubeVersion: '>=1.20.0'
+name: redhat-nodejs-imagestreams
+tags: builder,nodejs
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.2

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/README.md
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/README.md
@@ -1,0 +1,7 @@
+# NodeJS imagestream helm chart
+
+A Helm chart for importing NodeJS imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/templates/nodejs-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/templates/nodejs-imagestream.yaml
@@ -1,0 +1,165 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: nodejs
+  annotations:
+    openshift.io/display-name: Node.js
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Node.js (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      supports: nodejs
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 16-ubi8
+    referencePolicy:
+      type: Local
+  - name: 18-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-18:latest
+    referencePolicy:
+      type: Local
+  - name: 18-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-18-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 16-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-16:latest
+    referencePolicy:
+      type: Local
+  - name: 16-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-16-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 18-ubi8
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-18:latest
+    referencePolicy:
+      type: Local
+  - name: 18-ubi8-minimal
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 8 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 8 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-18-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 16-ubi8
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-16:latest
+    referencePolicy:
+      type: Local
+  - name: 16-ubi8-minimal
+    annotations:
+      openshift.io/display-name: Node.js 16 (UBI 8 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 16 applications on UBI 8 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '16'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-16-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 14-ubi7
+    annotations:
+      openshift.io/display-name: Node.js 14 (UBI 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 14 applications on UBI 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs,hidden
+      version: '14'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi7/nodejs-14:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "nodejs-imagestream-test"
+      image: "registry.access.redhat.com/ubi8/nodejs-18"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          node -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/values.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.2/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: helm-chart-testing


### PR DESCRIPTION
Output from helm-verifier

```bash
results:
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: PASS
      reason: Chart tests have passed
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: 'Image is Red Hat certified : registry.access.redhat.com/ubi8/nodejs-18'

```