### PR TITLE
Add support for Red Hat Perl imagestreams helm charts.

### DIFF
--- a/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,16 @@
+description: |-
+  This content is experimental, do not use it in production. Perl imagestreams for using on OpenShift 4.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Perl imagestreams (experimental).
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: redhat-perl-imagestreams
+tags: builder,perl
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/README.md
+++ b/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/README.md
@@ -1,0 +1,7 @@
+# Perl imagestreams helm chart
+
+A Helm chart for importing Perl imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/templates/perl-imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/templates/perl-imagestreams.yaml
@@ -1,0 +1,122 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: perl
+  annotations:
+    openshift.io/display-name: Perl
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Perl (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Perl applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major version updates.
+      iconClass: icon-perl
+      tags: builder,perl
+      supports: perl
+      sampleRepo: https://github.com/sclorg/dancer-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 5.32-ubi8
+    referencePolicy:
+      type: Local
+  - name: 5.32-ubi9
+    annotations:
+      openshift.io/display-name: Perl 5.32 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Perl 5.32 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.
+      iconClass: icon-perl
+      tags: builder,perl
+      supports: perl:5.32,perl
+      version: '5.32'
+      sampleRepo: https://github.com/sclorg/dancer-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/perl-532:latest
+    referencePolicy:
+      type: Local
+  - name: 5.32-ubi8
+    annotations:
+      openshift.io/display-name: Perl 5.32 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Perl 5.32 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.
+      iconClass: icon-perl
+      tags: builder,perl
+      supports: perl:5.32,perl
+      version: '5.32'
+      sampleRepo: https://github.com/sclorg/dancer-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/perl-532:latest
+    referencePolicy:
+      type: Local
+  - name: 5.30-ubi8
+    annotations:
+      openshift.io/display-name: Perl 5.30 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Perl 5.30 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30-mod_fcgid/README.md.
+      iconClass: icon-perl
+      tags: builder,perl
+      supports: perl:5.30,perl
+      version: '5.30'
+      sampleRepo: https://github.com/sclorg/dancer-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/perl-530:latest
+    referencePolicy:
+      type: Local
+  - name: 5.30-el7
+    annotations:
+      openshift.io/display-name: Perl 5.30 (RHEL 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Perl 5.30 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.
+      iconClass: icon-perl
+      tags: builder,perl
+      supports: perl:5.30,perl
+      version: '5.30'
+      sampleRepo: https://github.com/sclorg/dancer-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/rhscl/perl-530-rhel7:latest
+    referencePolicy:
+      type: Local
+  - name: '5.30'
+    annotations:
+      openshift.io/display-name: Perl 5.30
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Perl 5.30 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.
+      iconClass: icon-perl
+      tags: builder,perl,hidden
+      supports: perl:5.30,perl
+      version: '5.30'
+      sampleRepo: https://github.com/sclorg/dancer-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/rhscl/perl-530-rhel7:latest
+    referencePolicy:
+      type: Local
+  - name: 5.26-ubi8
+    annotations:
+      openshift.io/display-name: Perl 5.26 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Perl 5.26 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26-mod_fcgid/README.md.
+      iconClass: icon-perl
+      tags: builder,perl
+      supports: perl:5.26,perl
+      version: '5.26'
+      sampleRepo: https://github.com/sclorg/dancer-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/perl-526:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "perl-imagestream-test"
+      image: "registry.access.redhat.com/ubi9/perl-532"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          perl -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/redhat-perl-imagestreams/0.0.1/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: openshift


### PR DESCRIPTION
Result from helm verifier:
```bash
results:
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: 'Image is Red Hat certified : registry.access.redhat.com/ubi9/perl-532'
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: PASS
      reason: Chart tests have passed
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
```