### PR TITLE
Add PHP imagestreams Red Hat helm chart

### DIFF
--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is expermental, do not use it in production. Import PHP imagestreams to OpenShift 4.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-php-container/blob/master/8.1/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat PHP imagestreams on UBI (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: php-imagestreams
+tags: builder,php
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/Chart.yaml
@@ -7,7 +7,7 @@ annotations:
 apiVersion: v2
 appVersion: 0.0.1
 kubeVersion: '>=1.20.0'
-name: php-imagestreams
+name: redhat-php-imagestreams
 tags: builder,php
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/README.md
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/README.md
@@ -1,0 +1,7 @@
+# PHP imagestreams helm chart
+
+A Helm chart for importing PHP imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/templates/php-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/templates/php-imagestream.yaml
@@ -1,0 +1,123 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: php
+  annotations:
+    openshift.io/display-name: PHP
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: PHP (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run PHP applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of PHP available on OpenShift, including major version updates.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 8.0-ubi8
+    referencePolicy:
+      type: Local
+  - name: 8.1-ubi9
+    annotations:
+      openshift.io/display-name: PHP 8.1 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.1 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.1/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.1,php
+      version: '8.1'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/php-81:latest
+    referencePolicy:
+      type: Local
+  - name: 8.0-ubi9
+    annotations:
+      openshift.io/display-name: PHP 8.0 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.0 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.0,php
+      version: '8.0'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/php-80:latest
+    referencePolicy:
+      type: Local
+  - name: 8.0-ubi8
+    annotations:
+      openshift.io/display-name: PHP 8.0 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.0 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.0,php
+      version: '8.0'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/php-80:latest
+    referencePolicy:
+      type: Local
+  - name: 7.4-ubi8
+    annotations:
+      openshift.io/display-name: PHP 7.4 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 7.4 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.4/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:7.4,php
+      version: '7.4'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/php-74:latest
+    referencePolicy:
+      type: Local
+  - name: 7.3-ubi7
+    annotations:
+      openshift.io/display-name: PHP 7.3 (UBI 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 7.3 applications on UBI 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:7.3,php
+      version: '7.3'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi7/php-73:latest
+    referencePolicy:
+      type: Local
+  - name: '7.3'
+    annotations:
+      openshift.io/display-name: PHP 7.3
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 7.3 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.
+      iconClass: icon-php
+      tags: builder,php,hidden
+      supports: php:7.3,php
+      version: '7.3'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/rhscl/php-73-rhel7:latest
+    referencePolicy:
+      type: Local
+

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "php-imagestream-test"
+      image: "registry.access.redhat.com/ubi9/php-81"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          php -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.1/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: openshift


### PR DESCRIPTION
Add PHP imagestreams Red Hat helm chart

Result from helm verifier:

```bash
results:
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: PASS
      reason: Chart tests have passed
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: 'Image is Red Hat certified : registry.access.redhat.com/ubi9/php-81'
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
```