### PR TITLE
Add Python imagestreams Red Hat helm charts

### DIFF
--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,16 @@
+description: |-
+  This content is experimental, do not use it in production. Python imagestreams for using on OpenShift 4.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Python imagestreams (experimental).
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: redhat-python-imagestreams
+tags: builder,python
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/README.md
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/README.md
@@ -1,0 +1,7 @@
+# Python imagestreams helm chart
+
+A Helm chart for importing Python imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/templates/python-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/templates/python-imagestream.yaml
@@ -1,0 +1,170 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: python
+  annotations:
+    openshift.io/display-name: Python
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Python (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 3.9-ubi8
+    referencePolicy:
+      type: Local
+  - name: 3.11-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.11 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.11 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.11,python
+      version: '3.11'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-311:latest
+    referencePolicy:
+      type: Local
+  - name: 3.9-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.9 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.9 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.9,python
+      version: '3.9'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-39:latest
+    referencePolicy:
+      type: Local
+  - name: 3.11-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.11 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.11 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.11,python
+      version: '3.11'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-311:latest
+    referencePolicy:
+      type: Local
+  - name: 3.9-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.9 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.9 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.9,python
+      version: '3.9'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-39:latest
+    referencePolicy:
+      type: Local
+  - name: 3.8-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.8 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.8 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.8,python
+      version: '3.8'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-38:latest
+    referencePolicy:
+      type: Local
+  - name: 3.8-ubi7
+    annotations:
+      openshift.io/display-name: Python 3.8 (UBI 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.8 applications on UBI 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.8,python
+      version: '3.8'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi7/python-38:latest
+    referencePolicy:
+      type: Local
+  - name: '3.8'
+    annotations:
+      openshift.io/display-name: Python 3.8
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.8 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.
+      iconClass: icon-python
+      tags: builder,python,hidden
+      supports: python:3.8,python
+      version: '3.8'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/rhscl/python-38-rhel7:latest
+    referencePolicy:
+      type: Local
+  - name: 3.6-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.6 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.6 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.6,python
+      version: '3.6'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-36:latest
+    referencePolicy:
+      type: Local
+  - name: 2.7-ubi8
+    annotations:
+      openshift.io/display-name: Python 2.7 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 2.7 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:2.7,python
+      version: '2.7'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-27:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "perl-imagestream-test"
+      image: "registry.access.redhat.com/ubi9/python-311"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          python -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.1/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: openshift


### PR DESCRIPTION
Add Python imagestreams Red Hat helm charts

Result from helm verifier is:

```bash
results:
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: PASS
      reason: Chart tests have passed
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: PASS
      reason: 'Image is Red Hat certified : registry.access.redhat.com/ubi9/python-311'
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
```