### PR TITLE
Add Ruby imagestreams Red Hat helm chart

### DIFF
--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is experimental, do not use it in production. Ruby imagestreams on UBI.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Ruby imagestreams on UBI (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: redhat-ruby-imagestreams
+tags: builder,ruby
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/README.md
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/README.md
@@ -1,0 +1,7 @@
+# Ruby imagestreams helm chart
+
+A Helm chart for importing Ruby imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/templates/ruby-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/templates/ruby-imagestream.yaml
@@ -1,0 +1,122 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: ruby
+  annotations:
+    openshift.io/display-name: Ruby
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Ruby (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.0/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 3.0-ubi8
+    referencePolicy:
+      type: Local
+  - name: 3.1-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 3.1 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.1 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.1,ruby
+      version: '3.1'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-31:latest
+    referencePolicy:
+      type: Local
+  - name: 3.0-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 3.0 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.0 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.0,ruby
+      version: '3.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-30:latest
+    referencePolicy:
+      type: Local
+  - name: 3.1-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 3.1 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.1 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.1,ruby
+      version: '3.1'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-31:latest
+    referencePolicy:
+      type: Local
+  - name: 3.0-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 3.0 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.0 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.0,ruby
+      version: '3.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-30:latest
+    referencePolicy:
+      type: Local
+  - name: 3.0-ubi7
+    annotations:
+      openshift.io/display-name: Ruby 3.0 (UBI 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.0 applications on UBI 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.0,ruby
+      version: '3.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi7/ruby-30:latest
+    referencePolicy:
+      type: Local
+  - name: 2.5-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 2.5 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 2.5 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:2.5,ruby
+      version: '2.5'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-25:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "ruby-imagestream-test"
+      image: "registry.redhat.io/ubi9/ruby-31:latest"
+      #image: "ruby:31-ubi9"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          ruby -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.1/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: openshift


### PR DESCRIPTION
Add Ruby imagestreams Red Hat helm chart

Result from helm verifier:

```bash
results:
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: SKIPPED
      reason: 'Image certification skipped : registry.redhat.io/ubi9/ruby-31:latest'
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: PASS
      reason: Chart tests have passed
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist

```