### PR TITLE
add OWNERS file for redhat/knative-istio-authz

### DIFF
--- a/charts/redhat/redhat/knative-istio-authz/OWNERS
+++ b/charts/redhat/redhat/knative-istio-authz/OWNERS
@@ -1,0 +1,11 @@
+chart:
+  name: knative-istio-authz
+  shortDescription: This is the Red Had Openshift Serverless knative-istio-authz chart
+publicPgpKey: null
+users:
+- githubUsername: Kaustubh-pande
+- githubUsername: pierDipi
+- githubUsername: rudyredhat1
+vendor:
+  label: redhat
+  name: Red Hat

--- a/charts/redhat/redhat/knative-istio-authz/OWNERS
+++ b/charts/redhat/redhat/knative-istio-authz/OWNERS
@@ -6,6 +6,8 @@ users:
 - githubUsername: Kaustubh-pande
 - githubUsername: pierDipi
 - githubUsername: rudyredhat1
+- githubUsername: ReToCode
+- githubUsername: mgencur
 vendor:
   label: redhat
   name: Red Hat


### PR DESCRIPTION
This is preparation for the initial release of Red Hat Openshift Serverless (knative-istio-authz chart). A chart will be added in a follow-up PR.

The users mentioned in file are Red Hatters.
```
users:
- githubUsername: Kaustubh-pande
- githubUsername: pierDipi
- githubUsername: rudyredhat1
- githubUsername: ReToCode
- githubUsername: mgencur
```