### PR TITLE
This Pull request migrates DeploymentConfig to Deployment

### DIFF
--- a/charts/redhat/redhat/httpd-template/0.0.5/src/Chart.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: This content is expermental, do not use it in production. An example Apache HTTP Server (httpd) application that serves static
+  content. For more information about using this template, including OpenShift considerations,
+  see https://github.com/sclorg/httpd-container/blob/master/README.md.
+name: httpd-template
+tags: quickstart,httpd
+version: 0.0.4
+kubeVersion: '>=1.20.0'
+annotations:
+  charts.openshift.io/name: Red Hat Apache HTTP Server (httpd) application (experimental).
+apiVersion: v2
+appVersion: 0.0.4
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/Chart.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/Chart.yaml
@@ -1,13 +1,13 @@
-description: This content is expermental, do not use it in production. An example Apache HTTP Server (httpd) application that serves static
+description: This content is experimental, do not use it in production. An example Apache HTTP Server (httpd) application that serves static
   content. For more information about using this template, including OpenShift considerations,
   see https://github.com/sclorg/httpd-container/blob/master/README.md.
 name: httpd-template
 tags: quickstart,httpd
-version: 0.0.4
 kubeVersion: '>=1.20.0'
+version: 0.0.5
 annotations:
   charts.openshift.io/name: Red Hat Apache HTTP Server (httpd) application (experimental).
 apiVersion: v2
-appVersion: 0.0.4
+appVersion: 0.0.5
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/README.md
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/README.md
@@ -1,0 +1,23 @@
+# Httpd helm chart
+
+A Helm chart for building and deploying a [Httpd](https://github/sclorg/httpd-container) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                                       | Description | Default | Additional Information |
+|---------------------------------------------| ----------- | -- | ---------------------- |
+| `name`                                      | The name assigned to all of the frontend objects defined in this helm chart. | `httpd-example` | |
+| `namespace`                                 | The OpenShift Namespace where the ImageStream resides. | `httpd-template` | |
+| `httpd_version`                             | Version of Httpd image to be used (2.4-el8, or latest). | `2.4-el8` |  |
+| `memory_limit`                              | Maximum amount of memory the container can use. | `521Mi` |  |
+| `source_repository_url`                     | The URL of the repository with your application source code. | `https://github.com/sclorg/httpd-ex.git` |  |
+| `source_repository_ref`                     | Set this to a branch name, tag or other ref of your repository if you are not using the default branch. |  |  |
+| `context_dir`                               | Set this to the relative path to your project if it is not in the root of your repository. |  |  |
+| `application_domain`                        | The exposed hostname that will route to the httpd service, if left blank a value will be defaulted. |  |  |
+| `generic_webhook_secret`                    | A secret string used to configure the Generic webhook. |  |  |
+| `github_webhook_secret`                     | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL. Not encrypted. |  |  |

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/templates/buildconfig.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/templates/buildconfig.yaml
@@ -1,0 +1,36 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    description: Defines how to build the application
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: httpd-example
+    template: httpd-example
+  name: {{ .Values.name }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.name }}:latest
+  source:
+    contextDir: {{ .Values.context_dir }}
+    git:
+      ref: {{ .Values.source_repository_ref }}
+      uri: {{ .Values.source_repository_url }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: httpd:{{ .Values.httpd_version }}
+    type: Source
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange
+  - type: GitHub
+    github:
+      secret: {{ .Values.github_webhook_secret }}
+  - type: Generic
+    generic:
+      secret: {{ .Values.generic_webhook_secret }}

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/templates/deployment.yaml
@@ -1,9 +1,19 @@
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   annotations:
     description: Defines how to deploy the application server
     template.alpha.openshift.io/wait-for-ready: "true"
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{ .Values.name }}:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
   labels:
     app: httpd-example
     template: httpd-example
@@ -11,9 +21,10 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: {{ .Values.name }}
+    matchLabels:
+      name: {{ .Values.name }}
   strategy:
-    type: Rolling
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -22,7 +33,7 @@ spec:
     spec:
       containers:
       - env: []
-        image: "{{ .Values.name }}:latest"
+        image: " "
         livenessProbe:
           httpGet:
             path: /
@@ -41,14 +52,3 @@ spec:
         resources:
           limits:
             memory: {{ .Values.memory_limit }}
-  triggers:
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - httpd-example
-      from:
-        kind: ImageStreamTag
-        name: "{{ .Values.name }}:latest"
-        namespace: {{ .Values.namespace }}
-    type: ImageChange
-  - type: ConfigChange

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/templates/deploymentconfig.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/templates/deploymentconfig.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: httpd-example
+    template: httpd-example
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    name: {{ .Values.name }}
+  strategy:
+    type: Rolling
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+      name: {{ .Values.name }}
+    spec:
+      containers:
+      - env: []
+        image: "{{ .Values.name }}:latest"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 3
+        name: httpd-example
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - httpd-example
+      from:
+        kind: ImageStreamTag
+        name: "{{ .Values.name }}:latest"
+        namespace: {{ .Values.namespace }}
+    type: ImageChange
+  - type: ConfigChange

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/templates/route.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/templates/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: httpd-example
+    template: httpd-example
+  name: {{ .Values.name }}
+spec:
+  host: {{ .Values.application_domain }}
+  to:
+    kind: Service
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/templates/service.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Exposes and load balances the application pods
+  labels:
+    app: httpd-example
+    template: httpd-example
+  name: {{ .Values.name }}
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/templates/tests/test-httpd-connection.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/templates/tests/test-httpd-connection.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.database_service_name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "httpd-connection-test"
+      image: "registry.redhat.io/rhel8/httpd-24:latest"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          curl {{ .Values.name }}.{{ .Release.Namespace}}:8080 | grep "{{ .Values.expected_str }}"
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/values.schema.json
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/values.schema.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "namespace": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string",
+            "description": "The name assigned to all of the frontend objects defined in this template."
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "httpd_version": {
+            "type": "string",
+            "description": "Specify HTTPD imagestream tag",
+            "enum": [ "latest", "2.4-el9", "2.4-el8", "2.4-el7" ]
+        },
+        "application_domain": {
+            "type": "string",
+            "description": "The exposed hostname that will route to the httpd service, if left blank a value will be defaulted."
+        },
+        "context_dir": {
+            "type": "string",
+            "description": "Set this to the relative path to your project if it is not in the root of your repository."
+        }
+    }
+}
+

--- a/charts/redhat/redhat/httpd-template/0.0.5/src/values.yaml
+++ b/charts/redhat/redhat/httpd-template/0.0.5/src/values.yaml
@@ -1,0 +1,11 @@
+application_domain: "" # TODO: must define a default value for .application_domain
+context_dir: "" # TODO: must define a default value for .context_dir
+generic_webhook_secret: "SOMETHING" # TODO: must define a default value for .generic_webhook_secret
+github_webhook_secret: "FOOBAR" # TODO: must define a default value for .github_webhook_secret
+httpd_version: 2.4-el8
+memory_limit: 512Mi
+name: httpd
+namespace: openshift
+source_repository_ref: master # TODO: must define a default value for .source_repository_ref
+source_repository_url: https://github.com/sclorg/httpd-ex.git
+expected_str: Welcome to your static httpd application on OpenShift


### PR DESCRIPTION
This pull request migrates DeploymentConfig to Deployment.
also file deploymentconfig.yaml is renamed to deployment.yaml.

Version is bumped to 0.0.5.

SCLORG upstream tests are passing
https://github.com/sclorg/helm-charts/pull/55

See an output here:
https://github.com/sclorg/helm-charts/pull/55#issuecomment-1847180021
