### PR TITLE
Add additional owners for redhat-dotnet-imagestreams.

### DIFF
--- a/charts/redhat/redhat/redhat-dotnet-imagestreams/OWNERS
+++ b/charts/redhat/redhat/redhat-dotnet-imagestreams/OWNERS
@@ -3,6 +3,8 @@ chart:
   description: This is the Red Hat .NET imagestreams chart
 publicPgpKey: null
 users:
+  - githubUsername: aslicerh
+  - githubUsername: omajid
   - githubUsername: tmds
 vendor:
   label: redhat


### PR DESCRIPTION
Syncs owners with https://github.com/openshift-helm-charts/charts/pull/1144.