### PR TITLE
Migrate MariaDB Helm chart from DeploymentConfig to Deployment

### DIFF
--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  MariaDB database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md.
+
+  NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
+name: mariadb-persistent
+tags: database,mariadb
+version: 0.0.1
+annotations:
+  charts.openshift.io/name: Red Hat MariaDB database service, with persistent storage (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/Chart.yaml
@@ -1,13 +1,14 @@
 description: |-
-  MariaDB database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md.
+  This content is expermental, do not use it in production. MariaDB database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md.
 
   NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
 name: mariadb-persistent
 tags: database,mariadb
-version: 0.0.1
+version: 0.0.2
+kubeVersion: '>=1.20.0'
 annotations:
-  charts.openshift.io/name: Red Hat MariaDB database service, with persistent storage (experimental).
+  charts.openshift.io/name: Red Hat MariaDB database service, with persistent storage (experimental)
 apiVersion: v2
-appVersion: 0.0.1
+appVersion: 0.0.2
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/Chart.yaml
@@ -8,6 +8,8 @@ version: 0.0.2
 kubeVersion: '>=1.20.0'
 annotations:
   charts.openshift.io/name: Red Hat MariaDB database service, with persistent storage (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
 appVersion: 0.0.2
 sources:

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/README.md
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/README.md
@@ -1,0 +1,22 @@
+# MariaDB helm chart
+
+A Helm chart for building and deploying a [MariaDB](https://github/sclorg/mariadb-container) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                                       | Description | Default | Additional Information |
+|---------------------------------------------| ----------- | -- | ---------------------- |
+| `database_service_name`                     | The name of the OpenShift Service exposed for the database. | `mariadb` | - |
+| `mysql_user`                                | Username for MariaDB user that will be used for accessing the database. | - | Expresion like: `user[A-Z0-9]{3}` |
+| `mysql_root_password`                       | Password for the MariaDB root user. | | Expression like: `[a-zA-Z0-9]{16}` |
+| `mysql_database`                            | Name of the MariaDB database accessed. | `sampledb` |  |
+| `mysql_password`                            | Password for the MariaDB connection user. |  | Expression like: `[a-zA-Z0-9]{16}` |
+| `mariadb_version`                             | Version of MariaDB image to be used (10.3-el7, 10.3-el8, or latest). | `10.3-el8` |  |
+| `namespace`                                 | The OpenShift Namespace where the ImageStream resides. | `openshift` | |
+| `memory_limit`                              | Maximum amount of memory the container can use. | `521Mi` |  |
+| `volume_capacity`                           | Volume space available for data, e.g. 512Mi, 2Gi. | `1Gi` |  |

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/deployment.yaml
@@ -1,16 +1,28 @@
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   annotations:
     template.alpha.openshift.io/wait-for-ready: "true"
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "mariadb:{{ .Values.mariadb_version }}"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
   labels:
     app.openshift.io/runtime: mariadb
     template: mariadb-persistent-template
   name: {{ .Values.database_service_name }}
+
 spec:
   replicas: 1
   selector:
-    name: {{ .Values.database_service_name }}
+    matchLabels:
+      name: {{ .Values.database_service_name }}
   strategy:
     type: Recreate
   template:
@@ -73,13 +85,3 @@ spec:
       - name: {{ .Values.database_service_name }}-data
         persistentVolumeClaim:
           claimName: {{ .Values.database_service_name }}
-  triggers:
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - mariadb
-      from:
-        kind: ImageStreamTag
-        name: mariadb:{{ .Values.mariadb_version }}
-    type: ImageChange
-  - type: ConfigChange

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/deploymentconfig.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/deploymentconfig.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app.openshift.io/runtime: mariadb
+    template: mariadb-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  replicas: 1
+  selector:
+    name: {{ .Values.database_service_name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.database_service_name }}
+    spec:
+      containers:
+      - env:
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              key: database-user
+              name: {{ .Values.database_service_name }}
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-password
+              name: {{ .Values.database_service_name }}
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-root-password
+              name: {{ .Values.database_service_name }}
+        - name: MYSQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database-name
+              name: {{ .Values.database_service_name }}
+        image: "mariadb:{{ .Values.mariadb_version }}"
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - MYSQL_PWD="$MYSQL_PASSWORD" mysqladmin -u $MYSQL_USER ping
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        name: mariadb
+        ports:
+        - containerPort: 3306
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - MYSQL_PWD="$MYSQL_PASSWORD" mysqladmin -u $MYSQL_USER ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}
+        volumeMounts:
+        - mountPath: /var/lib/mysql/data
+          name: {{ .Values.database_service_name }}-data
+      volumes:
+      - name: {{ .Values.database_service_name }}-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.database_service_name }}
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - mariadb
+      from:
+        kind: ImageStreamTag
+        name: mariadb:{{ .Values.mariadb_version }}
+    type: ImageChange
+  - type: ConfigChange

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/persistentvolumeclaim.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.openshift.io/runtime: mariadb
+    template: mariadb-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volume_capacity }}

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/secret.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    template.openshift.io/expose-database_name: ".data['database-name']}"
+    template.openshift.io/expose-password: "{.data['database-password']}"
+    template.openshift.io/expose-root_password: "{.data['database-root-password']}"
+    template.openshift.io/expose-username: "{.data['database-user']}"
+  labels:
+    app.openshift.io/runtime: mariadb
+    template: mariadb-persistent-template
+  name: {{ .Values.database_service_name }}
+stringData:
+  database-name: {{ .Values.mysql_database }}
+  database-password: {{ .Values.mysql_password }}
+  database-root-password: {{ .Values.mysql_root_password }}
+  database-user: {{ .Values.mysql_user }}

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/service.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    template.openshift.io/expose-uri: mysql://{.spec.clusterIP}:{.spec.ports[?(.name=="mariadb")].port}
+  labels:
+    app.openshift.io/runtime: mariadb
+    template: mariadb-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  ports:
+  - name: mariadb
+    port: 3306
+  selector:
+    name: {{ .Values.database_service_name }}

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/tests/test-mariadb-connection.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/templates/tests/test-mariadb-connection.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.database_service_name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "mariadb-connection-test"
+      image: "registry.redhat.io/rhel8/mariadb-105:latest"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: MARIADB_USER
+          value: "{{ .Values.mysql_user }}"
+        - name: MARIADB_PASSWORD
+          value: "{{ .Values.mysql_password }}"
+        - name: MARIADB_DATABASE
+          value: "{{ .Values.mysql_database }}"
+      command:
+        - /bin/bash
+        - -ec
+        - "echo \"SELECT 42 as testval\\g\" | mysql --connect-timeout=15 -h {{ .Values.database_service_name }} $MARIADB_DATABASE -u$MARIADB_USER -p$MARIADB_PASSWORD"
+  restartPolicy: Never

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/values.schema.json
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/values.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "database_service_name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "mysql_database": {
+            "type": "string"
+        },
+        "mysql_password": {
+            "type": "string"
+        },
+        "mysql_root_password": {
+            "type": "string"
+        },
+        "mysql_user": {
+            "type": "string"
+        },
+        "volume_capacity": {
+            "type": "string",
+            "title": "Persistent Volume Size",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 1,
+            "sliderMax": 100,
+            "sliderUnit": "Gi"
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Database memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "mariadb_version": {
+            "type": "string",
+            "description": "Specify mariadb imagestream tag",
+            "enum": [ "latest", "10.5-el9", "10.3-el8", "10.5-el8", "10.3-el7", "10.3", "10.5-el7" ]
+        }
+    }
+}
+

--- a/charts/redhat/redhat/mariadb-persistent/0.0.2/src/values.yaml
+++ b/charts/redhat/redhat/mariadb-persistent/0.0.2/src/values.yaml
@@ -1,0 +1,9 @@
+database_service_name: mariadb
+mariadb_version: 10.3-el8
+memory_limit: 512Mi
+mysql_database: testdb
+mysql_password: testu
+mysql_root_password: testur
+mysql_user: testu
+namespace: openshift
+volume_capacity: 1Gi


### PR DESCRIPTION
This pull request migrates MariaDB helm chart from DeploymentConfig -> Deployment.

The commits are:
- Copy version from 0.0.1->0.0.2
- Modify sources to Deployment

