### PR TITLE
Migration postgresql helm chart from DeploymentConfig -> Deployment

### DIFF
--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/Chart.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.
+
+  NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
+annotations:
+  charts.openshift.io/name: Red Hat PostgreSQL database service, with persistent storage.
+apiVersion: v2
+appVersion: 0.0.2
+name: postgresql-persistent
+tags: database,postgresql
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.2
+

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/Chart.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/Chart.yaml
@@ -1,14 +1,16 @@
 description: |-
-  PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.
+  This content is expermental, do not use it in production. PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.
 
   NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
 annotations:
-  charts.openshift.io/name: Red Hat PostgreSQL database service, with persistent storage.
+  charts.openshift.io/name: Red Hat PostgreSQL database service, with persistent storage (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.2
+appVersion: 0.0.3
 name: postgresql-persistent
 tags: database,postgresql
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.2
+version: 0.0.3
 

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/README.md
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/README.md
@@ -1,0 +1,79 @@
+# PostgreSQL helm chart
+
+This repository contains helm chart for PostgreSQL image build and deployed on OpenShift.
+
+For more information about helm charts see the offical [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## How to start with helm charts
+
+The first download and install Helm. Follow instructions mentioned [here](https://helm.sh/docs/intro/install/).
+
+## Prerequisite for PostgreSQL-persistent helm chart
+Before deploying helm chart to OpenShift, you have to create a package for postgresql-imagestream.
+See details [postgresql-imagestreams](../postgresql-imagestreams/README.md)
+
+
+## How to work with PostgreSQL-persistent helm chart
+
+The default PostgreSQL helm chart configuration is for RHEL7 PostgreSQL version 10.
+
+This can be done by command:
+
+```commandline
+$ helm package ./
+```
+
+that will create a helm package named, `postgresql-persistent-0.0.2.tgz` in this directory.
+
+The next step is to upload Helm Chart to OpenShift. This is done by command:
+
+```commandline
+$ helm install postgresql-persistent postgresql-persistent-0.0.2.tgz
+```
+
+In case you would like to use this helm chart for different versions and even RHEL versions.
+you need to modify installing command.
+
+E.g. For RHEL8
+
+```commandline
+$ helm install postgresql-persistent postgresql-persistent-0.0.2.tgz --set image.repository=registry.redhat.io/rhel8/postgresql-13 --set image.version=13
+```
+The values that can be overwritten are specified in file [values.yaml](./values.yaml)
+
+To test in PostgreSQL helm chart is working properly run command:
+
+```commandline
+$ helm test postgresql-persistent --logs
+```
+that will print output like:
+```commandline
+NAME: postgresql-persistent
+LAST DEPLOYED: Mon Mar 27 09:36:23 2023
+NAMESPACE: pgsql-13
+STATUS: deployed
+REVISION: 1
+TEST SUITE:     postgresql-persistent-connection-test
+Last Started:   Mon Mar 27 09:37:13 2023
+Last Completed: Mon Mar 27 09:37:19 2023
+Phase:          Succeeded
+
+POD LOGS: postgresql-persistent-connection-test
+postgresql-testing:5432 - accepting connections
+```
+## Troubleshooting
+For case you need a computer readable output you can add to command mentioned above option `-o json`.
+
+In case of installation failed for reason like:
+```commandline
+// Error: INSTALLATION FAILED: cannot re-use a name that is still in use
+```
+you have to uninstall previous PostgreSQL Helm Chart by command:
+
+```commandline
+$ helm uninstall postgresql-persistent
+```
+
+

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/README.md
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/README.md
@@ -1,79 +1,23 @@
 # PostgreSQL helm chart
 
-This repository contains helm chart for PostgreSQL image build and deployed on OpenShift.
+# MariaDB helm chart
 
-For more information about helm charts see the offical [Helm Charts Documentation](https://helm.sh/).
+A Helm chart for building and deploying a [PostgreSQL](https://github/sclorg/postgresql-container) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
 
 You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
 
-## How to start with helm charts
+## Values
+Below is a table of each value used to configure this chart.
 
-The first download and install Helm. Follow instructions mentioned [here](https://helm.sh/docs/intro/install/).
-
-## Prerequisite for PostgreSQL-persistent helm chart
-Before deploying helm chart to OpenShift, you have to create a package for postgresql-imagestream.
-See details [postgresql-imagestreams](../postgresql-imagestreams/README.md)
-
-
-## How to work with PostgreSQL-persistent helm chart
-
-The default PostgreSQL helm chart configuration is for RHEL7 PostgreSQL version 10.
-
-This can be done by command:
-
-```commandline
-$ helm package ./
-```
-
-that will create a helm package named, `postgresql-persistent-0.0.2.tgz` in this directory.
-
-The next step is to upload Helm Chart to OpenShift. This is done by command:
-
-```commandline
-$ helm install postgresql-persistent postgresql-persistent-0.0.2.tgz
-```
-
-In case you would like to use this helm chart for different versions and even RHEL versions.
-you need to modify installing command.
-
-E.g. For RHEL8
-
-```commandline
-$ helm install postgresql-persistent postgresql-persistent-0.0.2.tgz --set image.repository=registry.redhat.io/rhel8/postgresql-13 --set image.version=13
-```
-The values that can be overwritten are specified in file [values.yaml](./values.yaml)
-
-To test in PostgreSQL helm chart is working properly run command:
-
-```commandline
-$ helm test postgresql-persistent --logs
-```
-that will print output like:
-```commandline
-NAME: postgresql-persistent
-LAST DEPLOYED: Mon Mar 27 09:36:23 2023
-NAMESPACE: pgsql-13
-STATUS: deployed
-REVISION: 1
-TEST SUITE:     postgresql-persistent-connection-test
-Last Started:   Mon Mar 27 09:37:13 2023
-Last Completed: Mon Mar 27 09:37:19 2023
-Phase:          Succeeded
-
-POD LOGS: postgresql-persistent-connection-test
-postgresql-testing:5432 - accepting connections
-```
-## Troubleshooting
-For case you need a computer readable output you can add to command mentioned above option `-o json`.
-
-In case of installation failed for reason like:
-```commandline
-// Error: INSTALLATION FAILED: cannot re-use a name that is still in use
-```
-you have to uninstall previous PostgreSQL Helm Chart by command:
-
-```commandline
-$ helm uninstall postgresql-persistent
-```
-
-
+| Value                                       | Description | Default | Additional Information |
+|---------------------------------------------| ----------- | -- | ---------------------- |
+| `database_service_name`                     | The name of the OpenShift Service exposed for the database. | `postgresql` | - |
+| `postgresql_user`                           | Username for PostgreSQL user that will be used for accessing the database. | - | Expresion like: `user[A-Z0-9]{3}` |
+| `postgresql_database`                       | Name of the PostgreSQL database accessed. | `sampledb` |  |
+| `postgresql_password`                       | Password for the PostgreSQL connection user. |  | Expression like: `[a-zA-Z0-9]{16}` |
+| `postgresql_version`                           | Version of PostgreSQL image to be used (10-el7, 10-el8, or latest). | `10-el8` |  |
+| `namespace`                                 | The OpenShift Namespace where the ImageStream resides. | `openshift` | |
+| `memory_limit`                              | Maximum amount of memory the container can use. | `521Mi` |  |
+| `volume_capacity`                           | Volume space available for data, e.g. 512Mi, 2Gi. | `1Gi` |  |

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/deployment.yaml
@@ -1,17 +1,28 @@
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   annotations:
     template.alpha.openshift.io/wait-for-ready: "true"
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "postgresql:{{ .Values.image.tag }}"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
   labels:
     template: postgresql-persistent-template
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  name: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}
 spec:
   replicas: 1
   selector:
-    name: {{ .Values.database_service_name }}
+    matchLabels:
+      name: {{ .Values.database_service_name }}
   strategy:
     type: Recreate
   template:
@@ -20,8 +31,7 @@ spec:
         name: {{ .Values.database_service_name }}
     spec:
       containers:
-      - capabilities: {}
-        env:
+      - env:
         - name: POSTGRESQL_USER
           valueFrom:
             secretKeyRef:
@@ -37,7 +47,7 @@ spec:
             secretKeyRef:
               key: database-name
               name: {{ .Values.database_service_name }}
-        image: "postgresql:{{ .Values.image.tag }}"
+        image: " "
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -46,7 +56,7 @@ spec:
             - --live
           initialDelaySeconds: 120
           timeoutSeconds: 10
-        name: "postgresql-{{ .Values.image.tag }}-testing"
+        name: "postgresql-persistent"
         ports:
         - containerPort: {{ .Values.config.port }}
           protocol: TCP
@@ -72,16 +82,4 @@ spec:
       - name: {{ .Values.database_service_name }}-data
         persistentVolumeClaim:
           claimName: {{ .Values.database_service_name }}
-  triggers:
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - "postgresql-{{ .Values.image.tag }}-testing"
-      from:
-        kind: ImageStreamTag
-        name: "postgresql:{{ .Values.image.tag }}"
-        namespace: {{ .Values.namespace }}
-      lastTriggeredImage: ""
-    type: ImageChange
-  - type: ConfigChange
 status: {}

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/deploymentconfig.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/deploymentconfig.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    template: postgresql-persistent-template
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    name: {{ .Values.database_service_name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.database_service_name }}
+    spec:
+      containers:
+      - capabilities: {}
+        env:
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              key: database-user
+              name: {{ .Values.database_service_name }}
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-password
+              name: {{ .Values.database_service_name }}
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database-name
+              name: {{ .Values.database_service_name }}
+        image: "postgresql:{{ .Values.image.tag }}"
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+            - --live
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+        name: "postgresql-{{ .Values.image.tag }}-testing"
+        ports:
+        - containerPort: {{ .Values.config.port }}
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}
+        securityContext:
+          capabilities: {}
+          privileged: false
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: {{ .Values.database_service_name }}-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - name: {{ .Values.database_service_name }}-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.database_service_name }}
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - "postgresql-{{ .Values.image.tag }}-testing"
+      from:
+        kind: ImageStreamTag
+        name: "postgresql:{{ .Values.image.tag }}"
+        namespace: {{ .Values.namespace }}
+      lastTriggeredImage: ""
+    type: ImageChange
+  - type: ConfigChange
+status: {}

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/persistentvolumeclaim.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    template: postgresql-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volume_capacity }}

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/secret.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+    template.openshift.io/expose-password: '{.data[''database-password'']}'
+    template.openshift.io/expose-username: '{.data[''database-user'']}'
+  labels:
+    template: postgresql-persistent-template
+  name: {{ .Values.database_service_name }}
+stringData:
+  database-name: {{ .Values.config.postgresql_database }}
+  database-password: {{ .Values.config.postgresql_password }}
+  database-user: {{ .Values.config.postgresql_user }}

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/service.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+  labels:
+    template: postgresql-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  ports:
+  - name: postgresql
+    nodePort: 0
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    name: {{ .Values.database_service_name }}
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/tests/test-postgresql-connection.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/tests/test-postgresql-connection.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.database_service_name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "postgresql-{{ .Values.image.tag }}-connection-test"
+      image: "image-registry.openshift-image-registry.svc:5000/{{ .Values.namespace}}/postgresql:{{ .Values.image.tag }}"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: POSTGRESQL_USER
+          value: "{{ .Values.config.postgresql_user }}"
+        - name: PGPASSWORD
+          value: "{{ .Values.config.postgresql_password }}"
+        - name: POSTGRESQL_DATABASE
+          value: "{{ .Values.config.postgresql_database }}"
+        - name: POSTGRESQL_PORT
+          value: "{{ .Values.config.port }}"
+      command:
+        - /bin/bash
+        - -ec
+        - "PGPASSWORD=$PGPASSWORD /usr/bin/pg_isready -d $POSTGRESQL_DATABASE -h {{ .Values.database_service_name }} -p $POSTGRESQL_PORT -U $POSTGRESQL_USER"
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/tests/test-postgresql-connection.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/templates/tests/test-postgresql-connection.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   #serviceAccount: {{ .Values.serviceAccount }}
   containers:
-    - name: "postgresql-{{ .Values.image.tag }}-connection-test"
-      image: "image-registry.openshift-image-registry.svc:5000/{{ .Values.namespace}}/postgresql:{{ .Values.image.tag }}"
+    - name: "postgresql-connection-test"
+      image: "registry.redhat.io/rhel8/postgresql-13:latest"
       imagePullPolicy: IfNotPresent
       env:
         - name: POSTGRESQL_USER
@@ -24,8 +24,6 @@ spec:
           value: "{{ .Values.config.port }}"
       command:
         - /bin/bash
-        - -ec
+        - -exc
         - "PGPASSWORD=$PGPASSWORD /usr/bin/pg_isready -d $POSTGRESQL_DATABASE -h {{ .Values.database_service_name }} -p $POSTGRESQL_PORT -U $POSTGRESQL_USER"
-  lookupPolicy:
-    local: true
   restartPolicy: Never

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/values.schema.json
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/values.schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "database_service_name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "postgresql_database": {
+                    "type": "string"
+                },
+                "postgresql_password": {
+                    "type": "string"
+                },
+                "postgresql_user": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "volume_capacity": {
+            "type": "string",
+            "title": "Persistent Volume Size",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 1,
+            "sliderMax": 100,
+            "sliderUnit": "Gi"
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Database memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "tag": {
+                    "type": "string",
+                    "description": "Specify postgresql imagestream tag",
+                    "enum": ["latest", "13-el9", "13-el8", "13-el7", "12-el8", "12-el7", "12", "10-el8", "10-el7", "10" ]
+                }
+            }
+        }
+    }
+}

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/values.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/values.yaml
@@ -1,0 +1,11 @@
+database_service_name: postgresql-testing
+memory_limit: 512Mi
+namespace: postgresql-persistent-testing
+volume_capacity: 1Gi
+config:
+  postgresql_database: testdb
+  postgresql_password: testp
+  postgresql_user: testu
+  port: 5432
+image:
+  tag: "latest"

--- a/charts/redhat/redhat/postgresql-persistent/0.0.3/src/values.yaml
+++ b/charts/redhat/redhat/postgresql-persistent/0.0.3/src/values.yaml
@@ -1,4 +1,4 @@
-database_service_name: postgresql-testing
+database_service_name: postgresql-persistent
 memory_limit: 512Mi
 namespace: postgresql-persistent-testing
 volume_capacity: 1Gi
@@ -8,4 +8,4 @@ config:
   postgresql_user: testu
   port: 5432
 image:
-  tag: "latest"
+  tag: "13-el8"


### PR DESCRIPTION
This pull request migrate postgresql helm chart from DeploymentConfig -> Deployment.

The first commit copies version 0.0.2->0.0.3.

The second commit for tracking proposes modify sources to Deployment

The migration was fully tested by https://github.com/sclorg/helm-charts/pull/57