### PR TITLE
chore: extend Backstage ownership to kadel

### DIFF
--- a/charts/community/janus-idp/backstage/OWNERS
+++ b/charts/community/janus-idp/backstage/OWNERS
@@ -5,6 +5,7 @@ publicPgpKey: null
 users:
   - githubUsername: sabre1041
   - githubUsername: tumido
+  - githubUsername: kadel
 vendor:
   label: janus-idp
   name: Janus IDP


### PR DESCRIPTION
Extending Backstage and Developer Hub chart ownership to our new maintainer @kadel.