### PR TITLE
chore: extend DeveloperHub ownership to kadel

### DIFF
--- a/charts/redhat/redhat/developer-hub/OWNERS
+++ b/charts/redhat/redhat/developer-hub/OWNERS
@@ -8,6 +8,7 @@ users:
   - githubUsername: sabre1041
   - githubUsername: nickboldt
   - githubUsername: rhdh-bot
+  - githubUsername: kadel
 vendor:
   label: redhat
   name: Red Hat


### PR DESCRIPTION
Extending Backstage and Developer Hub chart ownership to our new maintainer @kadel.