### PR TITLE
CakePHP application template with no database

### DIFF
--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/Chart.yaml
@@ -1,6 +1,6 @@
 description: This content is experimental, do not use it in production. An example CakePHP application with no database. For more information
   about using this template, including OpenShift considerations, see https://github.com/sclorg/cakephp-ex/blob/master/README.md.
-name: php-cakephp-application
+name: cakephp-application-template
 tags: quickstart,php,cakephp
 version: 0.0.1
 kubeVersion: '>=1.20.0'

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: This content is experimental, do not use it in production. An example CakePHP application with no database. For more information
+  about using this template, including OpenShift considerations, see https://github.com/sclorg/cakephp-ex/blob/master/README.md.
+name: php-cakephp-application
+tags: quickstart,php,cakephp
+version: 0.0.1
+kubeVersion: '>=1.20.0'
+annotations:
+  charts.openshift.io/name: Red Hat Apache CakePHP application with no database (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.1
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/README.md
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/README.md
@@ -1,0 +1,26 @@
+# CakePHP application template with no database helm chart
+
+A Helm chart for building and deploying a [CakePHP-ex](https://github/sclorg/cakephp-ex) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                    | Description | Default | Additional Information |
+|--------------------------| ----------- |-|-|
+| `name`                   | The name assigned to all of the frontend objects defined in this helm chart. | `cakephp-example` | |
+| `namespace`              | The OpenShift Namespace where the ImageStream resides. | `cakephp-example` | |
+| `php_version `           | Version of PHP image to be used (8.1-ubi9 by default). | `8.1-ubi9` | |
+| `memory_limit`           | Maximum amount of memory the container can use. | `521Mi` | |
+| `source_repository_url`  | The URL of the repository with your application source code. | `https://github.com/sclorg/cakephp-ex.git` | |
+| `source_repository_ref`  | Set this to a branch name, tag or other ref of your repository if you are not using the default branch. | `master` | |
+| `context_dir`            | Set this to the relative path to your project if it is not in the root of your repository. | | |
+| `application_domain`     | The exposed hostname that will route to the httpd service, if left blank a value will be defaulted. | | |
+| `github_webhook_secret`  | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL. Not encrypted. | | |
+| `cakephp_secret_token`  | Set this to a long random string. | | |
+| `cakephp_security_salt`  | Security salt for session hash. | | |
+| `composer_mirror`  | The custom Composer mirror URL. | | |
+| `opcache_revalidate_freq`  | How often to check script timestamps for updates, in seconds. 0 will result in OPcache checking for updates on every request. | | |

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/buildconfig.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/buildconfig.yaml
@@ -1,0 +1,39 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    description: Defines how to build the application
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: cakephp-example
+    template: cakephp-example
+  name: {{ .Values.name }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.name }}:latest
+  postCommit:
+    script: ./vendor/bin/phpunit
+  source:
+    contextDir: {{ .Values.context_dir }}
+    git:
+      ref: {{ .Values.source_repository_ref }}
+      uri: {{ .Values.source_repository_url }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      env:
+      - name: COMPOSER_MIRROR
+        value: {{ .Values.composer_mirror }}
+      from:
+        kind: ImageStreamTag
+        name: php:{{ .Values.php_version }}
+        namespace: {{ .Values.namespace }}
+    type: Source
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange
+  - github:
+      secret: {{ .Values.github_webhook_secret }}
+    type: GitHub

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{ .Values.name }}:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: cakephp-example
+    template: cakephp-example
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+      name: {{ .Values.name }}
+    spec:
+      containers:
+      - env:
+        - name: CAKEPHP_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: cakephp-secret-token
+              name: {{ .Values.name }}
+        - name: PHP_CLEAR_ENV
+          value: "OFF"
+        - name: CAKEPHP_SECURITY_SALT
+          valueFrom:
+            secretKeyRef:
+              key: cakephp-security-salt
+              name: {{ .Values.name }}
+        - name: OPCACHE_REVALIDATE_FREQ
+          value: "{{ .Values.opcache_revalidate_freq }}"
+        image: " "
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 3
+        name: cakephp-example
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 60
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/imagestream.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/imagestream.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    description: Keeps track of changes in the application image
+  labels:
+    app: cakephp-example
+    template: cakephp-example
+  name: {{ .Values.name }}

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/route.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: cakephp-example
+    template: cakephp-example
+  name: {{ .Values.name }}
+spec:
+  host: {{ .Values.application_domain }}
+  to:
+    kind: Service
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/secret.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: cakephp-example
+    template: cakephp-example
+  name: {{ .Values.name }}
+stringData:
+  cakephp-secret-token: {{ .Values.cakephp_secret_token }}
+  cakephp-security-salt: {{ .Values.cakephp_security_salt }}

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Exposes and load balances the application pods
+  labels:
+    app: cakephp-example
+    template: cakephp-example
+  name: {{ .Values.name }}
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/tests/test-php-cakephp-connection.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/templates/tests/test-php-cakephp-connection.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.name }}
+    template: {{ .Values.name }}
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-connection-test"
+      image: "registry.redhat.io/ubi8/ubi:latest"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-exc'
+        - >
+          curl {{ .Values.name }}.{{ .Release.Namespace }}:8080 | grep "Welcome to CakePHP 4.5"
+  restartPolicy: Never

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/values.schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string",
+            "title": "The URL of the repository with your application source code."
+        },
+        "php_version": {
+            "type": "string",
+            "description": "Version of PHP image to be used (8.1-ubi9 by default).",
+            "enum": [ "latest", "8.0-ubi8", "8.1-ubi9",  "8.0-ubi9" ]
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Maximum amount of memory the container can use.",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "source_repository_url": {
+            "type": "string"
+        },
+        "source_repository_ref": {
+            "type": "string"
+        },
+        "context_dir": {
+            "type": "string",
+            "description": "Set this to the relative path to your project if it is not in the root of your repository."
+        },
+        "application_domain": {
+            "type": "string",
+            "description": "The exposed hostname that will route to the httpd service, if left blank a value will be defaulted."
+        },
+        "github_webhook_secret": {
+            "type": "string",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted."
+        },
+        "cakephp_secret_token": {
+            "type": "string",
+            "description": "Set this to a long random string."
+        },
+        "cakephp_security_salt": {
+            "type": "string",
+            "description": "Security salt for session hash."
+        },
+        "composer_mirror": {
+            "type": "string",
+            "description": "The custom Composer mirror URL."
+        },
+        "opcache_revalidate_freq": {
+            "type": "string",
+            "description": "How often to check script timestamps for updates, in seconds. 0 will result in OPcache checking for updates on every request."
+        }
+    }
+}

--- a/charts/redhat/redhat/cakephp-application-template/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/cakephp-application-template/0.0.1/src/values.yaml
@@ -1,0 +1,13 @@
+application_domain: "" # TODO: must define a default value for .application_domain
+cakephp_secret_token: "" # TODO: must define a default value for .cakephp_secret_token
+cakephp_security_salt: "" # TODO: must define a default value for .cakephp_security_salt
+composer_mirror: "" # TODO: must define a default value for .composer_mirror
+context_dir: "" # TODO: must define a default value for .context_dir
+github_webhook_secret: "SOMETHING" # TODO: must define a default value for .github_webhook_secret
+memory_limit: 512Mi
+name: cakephp-example
+namespace: openshift
+opcache_revalidate_freq: "2"
+php_version: 8.1-ubi9
+source_repository_ref: "4.X" # TODO: must define a default value for .source_repository_ref
+source_repository_url: https://github.com/sclorg/cakephp-ex.git


### PR DESCRIPTION
This pull request adds support for CakePHP application template with no database.

The upstream PR is located here: https://github.com/sclorg/helm-charts/pull/66

And the tests are passing:
```
test_php_cakephp_application.py::TestHelmCakePHPTemplate::test_curl_connection [32mPASSED[0m[32m [  7%][0m
test_php_cakephp_application.py::TestHelmCakePHPTemplate::test_by_helm_test [32mPASSED[0m[32m [ 15%][0m
test_php_imagestreams.py::TestHelmRHELPHPImageStreams::test_package_imagestream[8.1-ubi9-registry.redhat.io/ubi9/php-81:latest] [32mPASSED[0m[32m [ 23%][0m
test_php_imagestreams.py::TestHelmRHELPHPImageStreams::test_package_imagestream[8.0-ubi9-registry.redhat.io/ubi9/php-80:latest] [32mPASSED[0m[32m [ 30%][0m
test_php_imagestreams.py::TestHelmRHELPHPImageStreams::test_package_imagestream[8.0-ubi8-registry.redhat.io/ubi8/php-80:latest] [32mPASSED[0m[32m [ 38%][0m
test_php_imagestreams.py::TestHelmRHELPHPImageStreams::test_package_imagestream[7.4-ubi8-registry.redhat.io/ubi8/php-74:latest] [32mPASSED[0m[32m [ 46%][0m
test_php_imagestreams.py::TestHelmRHELPHPImageStreams::test_package_imagestream[7.3-ubi7-registry.redhat.io/ubi7/php-73:latest] [32mPASSED[0m[32m [ 53%][0m
test_php_imagestreams.py::TestHelmRHELPHPImageStreams::test_package_imagestream[7.3-registry.redhat.io/rhscl/php-73-rhel7:latest] [32mPASSED[0m[32m [ 61%][0m
test_php_imagestreams.py::TestHelmCentOSPHPImageStreams::test_package_imagestream[8.0-ubi9-registry.access.redhat.com/ubi9/php-80:latest] [32mPASSED[0m[32m [ 69%][0m
test_php_imagestreams.py::TestHelmCentOSPHPImageStreams::test_package_imagestream[8.0-ubi8-registry.access.redhat.com/ubi8/php-80:latest] [32mPASSED[0m[32m [ 76%][0m
test_php_imagestreams.py::TestHelmCentOSPHPImageStreams::test_package_imagestream[7.4-ubi8-registry.access.redhat.com/ubi8/php-74:latest] [32mPASSED[0m[32m [ 84%][0m
test_php_imagestreams.py::TestHelmCentOSPHPImageStreams::test_package_imagestream[7.3-ubi7-registry.access.redhat.com/ubi7/php-73:latest] [32mPASSED[0m[32m [ 92%][0m
test_php_imagestreams.py::TestHelmCentOSPHPImageStreams::test_package_imagestream[7.3-quay.io/centos7/php-73-centos7:latest] [32mPASSED[0m[32m [100%][0m

```

Result from verifier:
```
results:
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: FAIL
      reason: |-
        Image certification skipped : registry.redhat.io/ubi8/ubi:latest
        ImageCertify() = empty image found
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
```