### PR TITLE
Perl Dancer Application template helm chart

### DIFF
--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/Chart.yaml
@@ -1,0 +1,16 @@
+description: |-
+  This content is experimental, do not use it in production. An example Dancer application with no database. For more information
+  about using this template, including OpenShift considerations, 
+  see https://github.com/sclorg/dancer-ex/blob/master/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Dancer application on UBI (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+name: perl-dancer-template
+tags: quickstart,perl,dancer
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/README.md
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/README.md
@@ -1,0 +1,26 @@
+# Perl application template with no database helm chart
+
+A Helm chart for building and deploying a [Dancer-ex](https://github/sclorg/dancer-ex) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                    | Description                                                                                             | Default                                    | Additional Information |
+|--------------------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------|------------------------|
+| `name`                   | The name assigned to all of the frontend objects defined in this helm chart.                            | `dancer-example`                           |                        |
+| `namespace`              | The OpenShift Namespace where the ImageStream resides.                                                  | `dancer-example`                           |                        |
+| `perl_version `          | Specify PERL imagestream tag.                                                                           | `5.30-ubi8`                                |                        |
+| `memory_limit`           | Maximum amount of memory the container can use.                                                         | `521Mi`                                    |                        |
+| `application_domain`     | The exposed hostname that will route to the httpd service, if left blank a value will be defaulted.     |                                            |                        |
+| `context_dir`            | Set this to the relative path to your project if it is not in the root of your repository.              |                                            |                        |
+| `cpan_mirror`            | The custom CPAN mirror URL.                                                                             |                                            |                        |
+| `github_webhook_secret`  | Github trigger secret. A difficult to guess string encoded as part of the webhook URL. Not encrypted.   |                                            |                        |
+| `source_repository_url`  | The URL of the repository with your application source code.                                            | `https://github.com/sclorg/cakephp-ex.git` |                        |
+| `source_repository_ref`  | Set this to a branch name, tag or other ref of your repository if you are not using the default branch. | `master`                                   |                        |
+| `perl_apache2_reload`    | Set this to \"true\" to enable automatic reloading of modified Perl modules.                            |                                            |                        |
+| `secret_key_base`        | Your secret key for verifying the integrity of signed cookies.                                          |                                            |                        |
+

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/buildconfig.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/buildconfig.yaml
@@ -1,0 +1,38 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    description: Defines how to build the application
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: dancer-example
+    template: dancer-example
+  name: {{ .Values.name }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.name }}:latest
+  postCommit:
+    script: perl -I extlib/lib/perl5 -I lib t/*
+  source:
+    contextDir: {{ .Values.context_dir }}
+    git:
+      ref: {{ .Values.source_repository_ref }}
+      uri: {{ .Values.source_repository_url }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      env:
+      - name: CPAN_MIRROR
+        value: {{ .Values.cpan_mirror }}
+      from:
+        kind: ImageStreamTag
+        name: perl:{{ .Values.perl_version }}
+    type: Source
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange
+  - github:
+      secret: {{ .Values.github_webhook_secret }}
+    type: GitHub

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{ .Values.name }}:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: dancer-example
+    template: dancer-example
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+      name: {{ .Values.name }}
+    spec:
+      containers:
+      - env:
+        - name: PERL_APACHE2_RELOAD
+          value: {{ .Values.perl_apache2_reload }}
+        image: " "
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 3
+        name: {{  .Values.name }}
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/imagestream.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/imagestream.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    description: Keeps track of changes in the application image
+  labels:
+    app: dancer-example
+    template: dancer-example
+  name: {{ .Values.name }}

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/route.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: dancer-example
+    template: dancer-example
+  name: {{ .Values.name }}
+spec:
+  host: {{ .Values.application_domain }}
+  to:
+    kind: Service
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Exposes and load balances the application pods
+  labels:
+    app: dancer-example
+    template: dancer-example
+  name: {{ .Values.name }}
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/tests/test-dancer-connection.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/templates/tests/test-dancer-connection.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.name }}
+    template: {{ .Values.name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "{{ .Release.Name }}-connection-test"
+      namespace: "{{ .Release.Namespace }}"
+      image: "registry.redhat.io/ubi8/perl-530:latest"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-exc'
+        - >
+          curl {{ .Values.name }}.{{ .Release.Namespace }}:8080 | grep "{{ .Values.expected_str }}"
+  restartPolicy: Never

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/values.schema.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "namespace": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string",
+            "description": "The name assigned to all of the frontend objects defined in this template."
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "perl_version": {
+            "type": "string",
+            "description": "Specify PERL imagestream tag",
+            "enum": [ "latest", "5.30-el7", "5.26-ubi8", "5.30-ubi8", "5.30-ubi9", "5.32-ubi8", "5.32-ubi9" ]
+        },
+        "application_domain": {
+            "type": "string",
+            "description": "The exposed hostname that will route to the httpd service, if left blank a value will be defaulted."
+        },
+        "context_dir": {
+            "type": "string",
+            "description": "Set this to the relative path to your project if it is not in the root of your repository."
+        },
+        "cpan_mirror": {
+            "type": "string",
+            "description": "The custom CPAN mirror URL"
+        },
+        "github_webhook_secret": {
+            "type": "string",
+            "description": "Github trigger secret. A difficult to guess string encoded as part of the webhook URL. Not encrypted."
+        },
+        "perl_apache2_reload": {
+            "type": "string",
+            "description": "Set this to \\\"true\\\" to enable automatic reloading of modified Perl modules."
+        },
+        "secret_key_base": {
+          "type": "string",
+          "description": "Your secret key for verifying the integrity of signed cookies."
+        },
+        "source_repository_url": {
+            "type": "string",
+            "description": "The URL of the repository with your application source code."
+        },
+        "source_repository_ref": {
+            "type": "string",
+            "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+        }
+    }
+}
+

--- a/charts/redhat/redhat/perl-dancer-template/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/perl-dancer-template/0.0.1/src/values.yaml
@@ -1,0 +1,12 @@
+application_domain: "" # TODO: must define a default value for .application_domain
+context_dir: "" # TODO: must define a default value for .context_dir
+cpan_mirror: "" # TODO: must define a default value for .cpan_mirror
+github_webhook_secret: "SOMETHING" # TODO: must define a default value for .github_webhook_secret
+memory_limit: 512Mi
+name: dancer-example
+namespace: openshift
+perl_apache2_reload: "" # TODO: must define a default value for .perl_apache2_reload
+perl_version: 5.30-ubi8
+secret_key_base: "" # TODO: must define a default value for .secret_key_base
+source_repository_ref: master # TODO: must define a default value for .source_repository_ref
+source_repository_url: https://github.com/sclorg/dancer-ex.git


### PR DESCRIPTION
This pull request adds support for Perl Dancer application template with no database.

The upstream PR is located here: https://github.com/sclorg/helm-charts/pull/63

The upstream tests passed:
```
test_perl_dancer_app.py::TestHelmPerlDancerAppTemplate::test_dancer_application_curl_output [32mPASSED[0m[32m [  6%][0m
test_perl_dancer_app.py::TestHelmPerlDancerAppTemplate::test_dancer_application_helm_test [32mPASSED[0m[32m [ 12%][0m
test_perl_dancer_mysql_template.py::TestHelmPerlDancerMysqlAppTemplate::test_dancer_application [32mPASSED[0m[32m [ 18%][0m
test_perl_dancer_mysql_template.py::TestHelmPerlDancerMysqlAppTemplate::test_dancer_application_helm_test [32mPASSED[0m[32m [ 25%][0m
test_perl_imagestreams.py::TestHelmRHELPerlImageStreams::test_package_imagestream[5.32-ubi9-registry.redhat.io/ubi9/perl-532:latest] [32mPASSED[0m[32m [ 31%][0m
test_perl_imagestreams.py::TestHelmRHELPerlImageStreams::test_package_imagestream[5.32-ubi8-registry.redhat.io/ubi8/perl-532:latest] [32mPASSED[0m[32m [ 37%][0m
test_perl_imagestreams.py::TestHelmRHELPerlImageStreams::test_package_imagestream[5.30-ubi8-registry.redhat.io/ubi8/perl-530:latest] [32mPASSED[0m[32m [ 43%][0m
test_perl_imagestreams.py::TestHelmRHELPerlImageStreams::test_package_imagestream[5.30-el7-registry.redhat.io/rhscl/perl-530-rhel7:latest] [32mPASSED[0m[32m [ 50%][0m
test_perl_imagestreams.py::TestHelmRHELPerlImageStreams::test_package_imagestream[5.30-registry.redhat.io/rhscl/perl-530-rhel7:latest] [32mPASSED[0m[32m [ 56%][0m
test_perl_imagestreams.py::TestHelmRHELPerlImageStreams::test_package_imagestream[5.26-ubi8-registry.redhat.io/ubi8/perl-526:latest] [32mPASSED[0m[32m [ 62%][0m
test_perl_imagestreams.py::TestHelmCentOSPerlImageStreams::test_package_imagestream[5.32-ubi9-registry.access.redhat.com/ubi9/perl-532:latest] [32mPASSED[0m[32m [ 68%][0m
test_perl_imagestreams.py::TestHelmCentOSPerlImageStreams::test_package_imagestream[5.32-ubi8-registry.access.redhat.com/ubi8/perl-532:latest] [32mPASSED[0m[32m [ 75%][0m
test_perl_imagestreams.py::TestHelmCentOSPerlImageStreams::test_package_imagestream[5.30-ubi8-registry.access.redhat.com/ubi8/perl-530:latest] [32mPASSED[0m[32m [ 81%][0m
test_perl_imagestreams.py::TestHelmCentOSPerlImageStreams::test_package_imagestream[5.30-el7-quay.io/centos7/perl-530-centos7:latest] [32mPASSED[0m[32m [ 87%][0m
test_perl_imagestreams.py::TestHelmCentOSPerlImageStreams::test_package_imagestream[5.30-quay.io/centos7/perl-530-centos7:latest] [32mPASSED[0m[32m [ 93%][0m
test_perl_imagestreams.py::TestHelmCentOSPerlImageStreams::test_package_imagestream[5.26-ubi8-registry.access.redhat.com/ubi8/perl-526:latest] [32mPASSED[0m[32m [100%][0m
```
And the tests are passing:
```
results:
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: FAIL
      reason: |-
        ImageCertify() = empty image found
        Image certification skipped : registry.redhat.io/ubi8/perl-530:latest
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
```