### PR TITLE
Nginx-template helm chart

### DIFF
--- a/charts/redhat/redhat/nginx-template/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/Chart.yaml
@@ -1,0 +1,15 @@
+description: An example Nginx HTTP server and a reverse proxy (nginx) application
+  that serves static content. For more information about using this template, including
+  OpenShift considerations, see https://github.com/sclorg/nginx-ex/blob/master/README.md.
+name: nginx-template
+tags: quickstart,nginx
+version: 0.0.1
+kubeVersion: '>=1.20.0'
+annotations:
+  charts.openshift.io/name: Red Hat Nginx HTTP Server (nginx) application (experimental).
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.1
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/README.md
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/README.md
@@ -1,0 +1,23 @@
+# Nginx helm chart
+
+A Helm chart for building and deploying a [Nginx](https://github/sclorg/nginx-container) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                                       | Description | Default                                            | Additional Information |
+|---------------------------------------------| ----------- |----------------------------------------------------| ---------------------- |
+| `name`                                      | The name assigned to all of the frontend objects defined in this helm chart. | `httpd-example`                                    | |
+| `namespace`                                 | The OpenShift Namespace where the ImageStream resides. | `httpd-template`                                   | |
+| `nginx_version`                             | Version of NGINX image to be used (1.20-ubi8 by default). | `1.20-ubi8`                                        |  |
+| `memory_limit`                              | Maximum amount of memory the container can use. | `521Mi`                                            |  |
+| `source_repository_url`                     | The URL of the repository with your application source code. | `https://github.com/sclorg/nginx-ex.git` |  |
+| `source_repository_ref`                     | Set this to a branch name, tag or other ref of your repository if you are not using the default branch. |                                                    |  |
+| `context_dir`                               | Set this to the relative path to your project if it is not in the root of your repository. |                                                    |  |
+| `application_domain`                        | The exposed hostname that will route to the httpd service, if left blank a value will be defaulted. |                                                    |  |
+| `generic_webhook_secret`                    | A secret string used to configure the Generic webhook. |                                                    |  |
+| `github_webhook_secret`                     | Github trigger secret.  A difficult to guess string encoded as part of the webhook URL. Not encrypted. |                                                    |  |

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/templates/buildconfig.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/templates/buildconfig.yaml
@@ -1,0 +1,36 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    description: Defines how to build the application
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: {{ .Values.name }}
+    template: {{ .Values.name }}
+  name: {{ .Values.name }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.name }}:latest
+  source:
+    contextDir: {{ .Values.context_dir }}
+    git:
+      ref: {{ .Values.source_repository_ref }}
+      uri: {{ .Values.source_repository_url }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: nginx:{{ .Values.nginx_version }}
+    type: Source
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange
+  - github:
+      secret: {{ .Values.github_webhook_secret }}
+    type: GitHub
+  - generic:
+      secret: {{ .Values.generic_webhook_secret }}
+    type: Generic

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+    template.alpha.openshift.io/wait-for-ready: "true"
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{ .Values.name }}:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+  labels:
+    app: nginx-template
+    template: nginx-template
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+      name: {{ .Values.name }}
+    spec:
+      containers:
+      - env: []
+        image: " "
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 3
+        name: nginx-template
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/templates/imagestream.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/templates/imagestream.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    description: Keeps track of changes in the application image
+  labels:
+    app: dancer-example
+    template: dancer-example
+  name: {{ .Values.name }}

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/templates/route.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/templates/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
+  labels:
+    app: {{ .Values.name }}
+    template: {{ .Values.name }}
+  name: {{ .Values.name }}
+spec:
+  host: {{ .Values.application_domain }}
+  to:
+    kind: Service
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Exposes and load balances the application pods
+  labels:
+    app: {{ .Values.name }}
+    template: {{ .Values.name }}
+  name: {{ .Values.name }}
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/templates/tests/test-nginx-connection.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/templates/tests/test-nginx-connection.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.database_service_name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "nginx-connection-test"
+      image: "registry.redhat.io/ubi8/nginx-122:latest"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-exc'
+        - >
+          curl {{ .Values.name }}.{{ .Release.Namespace }}:8080 | grep "{{ .Values.expected_str }}"
+  restartPolicy: Never

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/values.schema.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string",
+            "title": "The URL of the repository with your application source code."
+        },
+        "nginx_version": {
+            "type": "string",
+            "description": "Version of NGINX image to be used (1.20-ubi8 by default).",
+            "enum": [ "latest", "1.20-ubi8", "1.20-ubi9",  "1.22-ubi8", "1.22-ubi9", "1.20-ubi7" ]
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Maximum amount of memory the container can use.",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "source_repository_url": {
+            "type": "string"
+        },
+        "source_repository_ref": {
+            "type": "string"
+        },
+        "context_dir": {
+            "type": "string",
+            "description": "Set this to the relative path to your project if it is not in the root of your repository."
+        },
+        "application_domain": {
+            "type": "string",
+            "description": "The exposed hostname that will route to the httpd service, if left blank a value will be defaulted."
+        },
+        "github_webhook_secret": {
+            "type": "string",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted."
+        },
+        "generic_webhook_secret": {
+            "type": "string",
+            "description": "A secret string used to configure the Generic webhook."
+        }
+    }
+}
+

--- a/charts/redhat/redhat/nginx-template/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/nginx-template/0.0.1/src/values.yaml
@@ -1,0 +1,9 @@
+context_dir: "" # TODO: must define a default value for .context_dir
+generic_webhook_secret: "SOMETHING" # TODO: must define a default value for .generic_webhook_secret
+github_webhook_secret: "FOOBAR" # TODO: must define a default value for .github_webhook_secret
+memory_limit: 512Mi
+name: nginx-example
+namespace: openshift
+nginx_version: 1.20-ubi8
+source_repository_ref: master # TODO: must define a default value for .source_repository_ref
+source_repository_url: https://github.com/sclorg/nginx-ex.git


### PR DESCRIPTION
This pull request adds support for Nginx template.

The upstream PR is located here: https://github.com/sclorg/helm-charts/pull/60

The upstream tests passed:
```
test_nginx_imagestreams.py::TestHelmRHELNginxImageStreams::test_package_imagestream[1.22-ubi9-registry.redhat.io/ubi9/nginx-122:latest] [32mPASSED[0m[32m [ 10%][0m
test_nginx_imagestreams.py::TestHelmRHELNginxImageStreams::test_package_imagestream[1.22-ubi8-registry.redhat.io/ubi8/nginx-122:latest] [32mPASSED[0m[32m [ 20%][0m
test_nginx_imagestreams.py::TestHelmRHELNginxImageStreams::test_package_imagestream[1.20-ubi9-registry.redhat.io/ubi9/nginx-120:latest] [32mPASSED[0m[32m [ 30%][0m
test_nginx_imagestreams.py::TestHelmRHELNginxImageStreams::test_package_imagestream[1.20-ubi8-registry.redhat.io/ubi8/nginx-120:latest] [32mPASSED[0m[32m [ 40%][0m
test_nginx_imagestreams.py::TestHelmRHELNginxImageStreams::test_package_imagestream[1.20-ubi7-registry.redhat.io/ubi7/nginx-120:latest] [32mPASSED[0m[32m [ 50%][0m
test_nginx_imagestreams.py::TestHelmCentOSNginxImageStreams::test_package_imagestream[1.20-ubi9-registry.access.redhat.com/ubi9/nginx-120:latest] [32mPASSED[0m[32m [ 60%][0m
test_nginx_imagestreams.py::TestHelmCentOSNginxImageStreams::test_package_imagestream[1.20-ubi8-registry.access.redhat.com/ubi8/nginx-120:latest] [32mPASSED[0m[32m [ 70%][0m
test_nginx_imagestreams.py::TestHelmCentOSNginxImageStreams::test_package_imagestream[1.20-ubi7-registry.access.redhat.com/ubi7/nginx-120:latest] [32mPASSED[0m[32m [ 80%][0m
test_nginx_template.py::TestHelmNginxTemplate::test_curl_connection [32mPASSED[0m[32m [ 90%][0m
test_nginx_template.py::TestHelmNginxTemplate::test_helm_connection [32mPASSED[0m[32m [100%][0m
```

Results are:
```
results:
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: FAIL
      reason: |-
        ImageCertify() = empty image found
        Image certification skipped : registry.redhat.io/ubi8/nginx-122:latest
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
```