### PR TITLE
Python Django Helm Chart application with no database

### DIFF
--- a/charts/redhat/redhat/python-django-application/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: This content is experimental, do not use it in production. An example Django application with no database. For more information
+  about using this template, including OpenShift considerations, see https://github.com/sclorg/django-ex/blob/master/README.md.
+name: python-django-application
+tags: quickstart,python,django
+version: 0.0.1
+annotations:
+  charts.openshift.io/name: Red Hat Dancer application on UBI (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/README.md
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/README.md
@@ -1,0 +1,25 @@
+# Python application template with no database helm chart
+
+A Helm chart for building and deploying a [Django-ex](https://github/sclorg/django-ex) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                   | Description                                                                                             | Default                                   | Additional Information |
+|-------------------------|---------------------------------------------------------------------------------------------------------|-------------------------------------------|------------------------|
+| `name`                  | The name assigned to all of the frontend objects defined in this helm chart.                            | `django-example`                          |                        |
+| `namespace`             | The OpenShift Namespace where the ImageStream resides.                                                  | `openshift`                               |                        |
+| `python_version `       | Specify Python imagestream tag.                                                                         | `3.11-ubi8`                               |                        |
+| `memory_limit`          | Maximum amount of memory the container can use.                                                         | `521Mi`                                   |                        |
+| `source_repository_url` | The URL of the repository with your application source code.                                            | `https://github.com/sclorg/django-ex.git` |                        |
+| `source_repository_ref` | Set this to a branch name, tag or other ref of your repository if you are not using the default branch. | `2.2.x`                                   |                        |
+| `context_dir`           | Set this to the relative path to your project if it is not in the root of your repository.              |                                           |                        |
+| `application_domain`    | The exposed hostname that will route to the httpd service, if left blank a value will be defaulted.     |                                           |                        |
+| `github_webhook_secret` | Github trigger secret. A difficult to guess string encoded as part of the webhook URL. Not encrypted.   |                                           |                        |
+| `django_secret_key`     | Set this to a long random string.                                                                       |                                           |                        |
+| `app_config`            | Relative path to Gunicorn configuration file (optional).                                                |                                           |                        |
+| `pip_index_url`         | The custom PyPi index URL.                                                                              |                                           |                        |

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/templates/buildconfig.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/templates/buildconfig.yaml
@@ -1,0 +1,39 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    description: Defines how to build the application
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: django-example
+    template: django-example
+  name: {{ .Values.name }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.name }}:latest
+  postCommit:
+    script: ./manage.py test
+  source:
+    contextDir: {{ .Values.context_dir }}
+    git:
+      ref: {{ .Values.source_repository_ref }}
+      uri: {{ .Values.source_repository_url }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      env:
+      - name: PIP_INDEX_URL
+        value: {{ .Values.pip_index_url }}
+      from:
+        kind: ImageStreamTag
+        name: python:{{ .Values.python_version }}
+        namespace: {{ .Values.namespace }}
+    type: Source
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange
+  - github:
+      secret: {{ .Values.github_webhook_secret }}
+    type: GitHub

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{ .Values.name }}:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: django-example
+    template: django-example
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+      name: {{ .Values.name }}
+    spec:
+      containers:
+      - env:
+        - name: APP_CONFIG
+          value: {{ .Values.app_config }}
+        - name: DJANGO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: django-secret-key
+              name: {{ .Values.name }}
+        image: ' '
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 3
+        name: django-example
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/templates/imagestream.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/templates/imagestream.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    description: Keeps track of changes in the application image
+  labels:
+    app: django-example
+    template: django-example
+  name: {{ .Values.name }}

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/templates/route.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/templates/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: django-example
+    template: django-example
+  name: {{ .Values.name }}
+spec:
+  host: {{ .Values.application_domain }}
+  to:
+    kind: Service
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/templates/secret.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: django-example
+    template: django-example
+  name: {{ .Values.name }}
+stringData:
+  django-secret-key: {{ .Values.django_secret_key }}

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Exposes and load balances the application pods
+  labels:
+    app: django-example
+    template: django-example
+  name: {{ .Values.name }}
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/templates/tests/test-django-connection.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/templates/tests/test-django-connection.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.name }}
+    template: {{ .Values.name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "{{ .Release.Name }}-connection-test"
+      namespace: "{{ .Release.Namespace }}"
+      image: "registry.redhat.io/ubi8/ubi:latest"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-exc'
+        - >
+          curl {{ .Values.name }}.{{ .Release.Namespace }}:8080 | grep "Welcome to your Django application"
+  restartPolicy: Never

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/values.schema.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "namespace": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string",
+            "description": "The name assigned to all of the frontend objects defined in this template."
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "python_version": {
+            "type": "string",
+            "description": "Specify Python imagestream tag",
+            "enum": [ "latest", "2.7-ubi8", "3.6-ubi8", "3.8-ubi8", "3.8-ubi7", "3.9-ubi8", "3.9-ubi9", "3.11-ubi8", "3.11-ubi9" ]
+        },
+        "application_domain": {
+            "type": "string",
+            "description": "The exposed hostname that will route to the httpd service, if left blank a value will be defaulted."
+        },
+        "context_dir": {
+            "type": "string",
+            "description": "Set this to the relative path to your project if it is not in the root of your repository."
+        },
+        "pip_index_url": {
+            "type": "string",
+            "description": "The custom PyPi index URL"
+        },
+        "github_webhook_secret": {
+            "type": "string",
+            "description": "Github trigger secret. A difficult to guess string encoded as part of the webhook URL. Not encrypted."
+        },
+        "app_config": {
+            "type": "string",
+            "description": "Relative path to Gunicorn configuration file (optional)."
+        },
+        "django_secret_key": {
+          "type": "string",
+          "description": "Set this to a long random string."
+        },
+        "source_repository_url": {
+            "type": "string",
+            "description": "The URL of the repository with your application source code."
+        },
+        "source_repository_ref": {
+            "type": "string",
+            "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+        }
+    }
+}
+

--- a/charts/redhat/redhat/python-django-application/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/python-django-application/0.0.1/src/values.yaml
@@ -1,0 +1,13 @@
+application_domain: "" # TODO: must define a default value for .application_domain
+context_dir: "" # TODO: must define a default value for .context_dir
+pip_index_url: "" # TODO: must define a default value for .cpan_mirror
+github_webhook_secret: "SOMETHING" # TODO: must define a default value for .github_webhook_secret
+memory_limit: 512Mi
+name: django-example
+namespace: openshift
+django_secret_key: "FOOBAR" # TODO: must define a default value for .perl_apache2_reload
+python_version: 3.11-ubi8
+source_repository_ref: 2.2.x # TODO: must define a default value for .source_repository_ref
+source_repository_url: https://github.com/sclorg/django-ex.git
+app_config: "" # TODO: must define a default value for .app_config
+


### PR DESCRIPTION
This pull request adds support for Python Django application with no database.

The upstream PR is located here: https://github.com/sclorg/helm-charts/pull/69

The upstream tests passed:
```
test_python_django_app.py::TestHelmPythonDjangoAppTemplate::test_django_application_curl_output [32mPASSED[0m[32m [  5%][0m
test_python_django_app.py::TestHelmPythonDjangoAppTemplate::test_django_application_helm_test [32mPASSED[0m[32m [ 11%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.11-ubi9-registry.redhat.io/ubi9/python-311:latest] [32mPASSED[0m[32m [ 17%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.11-ubi8-registry.redhat.io/ubi8/python-311:latest] [32mPASSED[0m[32m [ 23%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.9-ubi9-registry.redhat.io/ubi9/python-39:latest] [32mPASSED[0m[32m [ 29%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.9-ubi8-registry.redhat.io/ubi8/python-39:latest] [32mPASSED[0m[32m [ 35%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.8-ubi8-registry.redhat.io/ubi8/python-38:latest] [32mPASSED[0m[32m [ 41%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.8-ubi7-registry.redhat.io/ubi7/python-38:latest] [32mPASSED[0m[32m [ 47%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.8-registry.redhat.io/rhscl/python-38-rhel7:latest] [32mPASSED[0m[32m [ 52%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[3.6-ubi8-registry.redhat.io/ubi8/python-36:latest] [32mPASSED[0m[32m [ 58%][0m
test_python_imagestreams.py::TestHelmRHELPythonImageStreams::test_package_imagestream[2.7-ubi8-registry.redhat.io/ubi8/python-27:latest] [32mPASSED[0m[32m [ 64%][0m
test_python_imagestreams.py::TestHelmCentOSPythonImageStreams::test_package_imagestream[3.9-ubi9-registry.access.redhat.com/ubi9/python-39:latest] [32mPASSED[0m[32m [ 70%][0m
test_python_imagestreams.py::TestHelmCentOSPythonImageStreams::test_package_imagestream[3.9-ubi8-registry.access.redhat.com/ubi8/python-39:latest] [32mPASSED[0m[32m [ 76%][0m
test_python_imagestreams.py::TestHelmCentOSPythonImageStreams::test_package_imagestream[3.8-ubi8-registry.access.redhat.com/ubi8/python-38:latest] [32mPASSED[0m[32m [ 82%][0m
test_python_imagestreams.py::TestHelmCentOSPythonImageStreams::test_package_imagestream[3.8-ubi7-registry.access.redhat.com/ubi7/python-38:latest] [32mPASSED[0m[32m [ 88%][0m
test_python_imagestreams.py::TestHelmCentOSPythonImageStreams::test_package_imagestream[3.6-ubi8-registry.access.redhat.com/ubi8/python-36:latest] [32mPASSED[0m[32m [ 94%][0m
test_python_imagestreams.py::TestHelmCentOSPythonImageStreams::test_package_imagestream[2.7-ubi8-registry.access.redhat.com/ubi8/python-27:latest] [32mPASSED[0m[32m [100%][0m
```

Results from helm verify are:
```
results:
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: FAIL
      reason: |-
        ImageCertify() = empty image found
        Image certification skipped : registry.redhat.io/ubi8/ubi:latest
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
```