### PR TITLE
Helm Chart for Rails application with no database

### DIFF
--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: This content is experimental, do not use it in production. An example Rails application with no database. For more information about
+  using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.
+name: ruby-rails-application
+tags: quickstart,ruby,rails
+version: 0.0.1
+kubeVersion: '>=1.20.0'
+annotations:
+  charts.openshift.io/name: Red Hat Apache Rails application with no database (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.1
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/README.md
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/README.md
@@ -1,0 +1,25 @@
+# Rails application template with no database helm chart
+
+A Helm chart for building and deploying a [Rails-ex](https://github/sclorg/rails-ex) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                   | Description                                                                                               | Default                                  | Additional Information |
+|-------------------------|-----------------------------------------------------------------------------------------------------------|------------------------------------------|------------------------|
+| `name`                  | The name assigned to all of the frontend objects defined in this helm chart.                              | `django-example`                         |                        |
+| `namespace`             | The OpenShift Namespace where the ImageStream resides.                                                    | `openshift`                              |                        |
+| `ruby_version `         | Specify Ruby imagestream tag.                                                                             | `3.1-ubi8`                               |                        |
+| `memory_limit`          | Maximum amount of memory the container can use.                                                           | `521Mi`                                  |                        |
+| `source_repository_url` | The URL of the repository with your application source code.                                              | `https://github.com/sclorg/rails-ex.git` |                        |
+| `source_repository_ref` | Set this to a branch name, tag or other ref of your repository if you are not using the default branch.   | `master`                                 |                        |
+| `context_dir`           | Set this to the relative path to your project if it is not in the root of your repository.                |                                          |                        |
+| `application_domain`    | The exposed hostname that will route to the httpd service, if left blank a value will be defaulted.       |                                          |                        |
+| `github_webhook_secret` | Github trigger secret. A difficult to guess string encoded as part of the webhook URL. Not encrypted.     |                                          |                        |
+| `rails_env`             | Environment under which the sample application will run. Could be set to production, development or test. |                                          |                        |
+| `secret_key_base`       | Your secret key for verifying the integrity of signed cookies.                                            |                                          |                        |
+| `rubygem_mirror`        | The custom RubyGems mirror URL.                                                                           |                                          |                        |

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/buildconfig.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/buildconfig.yaml
@@ -1,0 +1,37 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    description: Defines how to build the application
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: rails-example
+    template: rails-example
+  name: {{ .Values.name }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.name }}:latest
+  source:
+    contextDir: {{ .Values.context_dir }}
+    git:
+      ref: {{ .Values.source_repository_ref }}
+      uri: {{ .Values.source_repository_url }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      env:
+      - name: RUBYGEM_MIRROR
+        value: {{ .Values.rubygem_mirror }}
+      from:
+        kind: ImageStreamTag
+        name: ruby:{{ .Values.ruby_version }}
+        namespace: {{ .Values.namespace }}
+    type: Source
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange
+  - github:
+      secret: {{ .Values.github_webhook_secret }}
+    type: GitHub

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{ .Values.name }}:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: rails-example
+    template: rails-example
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+      name: {{ .Values.name }}
+    spec:
+      containers:
+      - env:
+        - name: RAILS_ENV
+          value: {{ .Values.rails_env }}
+        image: ' '
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 3
+        name: rails-example
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/imagestream.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/imagestream.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    description: Keeps track of changes in the application image
+  labels:
+    app: rails-example
+    template: rails-example
+  name: {{ .Values.name }}

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/route.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: rails-example
+    template: rails-example
+  name: {{ .Values.name }}
+spec:
+  host: {{ .Values.application_domain }}
+  to:
+    kind: Service
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Exposes and load balances the application pods
+  labels:
+    app: rails-example
+    template: rails-example
+  name: {{ .Values.name }}
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/tests/test-ruby-rails-connection.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/templates/tests/test-ruby-rails-connection.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.name }}
+    template: {{ .Values.name }}
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-connection-test"
+      image: "registry.redhat.io/ubi8/ubi:latest"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-exc'
+        - >
+          curl {{ .Values.name }}.{{ .Release.Namespace }}:8080 | grep "Welcome to your Rails application"
+  restartPolicy: Never

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/values.schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string",
+            "title": "The URL of the repository with your application source code."
+        },
+        "ruby_version": {
+            "type": "string",
+            "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
+            "enum": [ "latest", "3.0-ubi8", "3.1-ubi8",  "3.0-ubi9", "3.1-ubi9" ]
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Maximum amount of memory the container can use.",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "source_repository_url": {
+            "type": "string"
+        },
+        "source_repository_ref": {
+            "type": "string"
+        },
+        "context_dir": {
+            "type": "string",
+            "description": "Set this to the relative path to your project if it is not in the root of your repository."
+        },
+        "application_domain": {
+            "type": "string",
+            "description": "The exposed hostname that will route to the httpd service, if left blank a value will be defaulted."
+        },
+        "github_webhook_secret": {
+            "type": "string",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted."
+        },
+        "secret_key_base": {
+            "type": "string",
+            "description": "Your secret key for verifying the integrity of signed cookies."
+        },
+        "rails_env": {
+            "type": "string",
+            "description": "Environment under which the sample application will run. Could be set to production, development or test."
+        },
+        "rubygem_mirror": {
+            "type": "string",
+            "description": "The custom RubyGems mirror URL."
+        }
+    }
+}

--- a/charts/redhat/redhat/ruby-rails-application/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/ruby-rails-application/0.0.1/src/values.yaml
@@ -1,0 +1,12 @@
+application_domain: "" # TODO: must define a default value for .application_domain
+context_dir: "" # TODO: must define a default value for .context_dir
+github_webhook_secret: "SOMETHING" # TODO: must define a default value for .github_webhook_secret
+memory_limit: 512Mi
+name: rails-example
+namespace: openshift
+rails_env: production
+ruby_version: 3.1-ubi8
+rubygem_mirror: "" # TODO: must define a default value for .rubygem_mirror
+secret_key_base: "" # TODO: must define a default value for .secret_key_base
+source_repository_ref: "master" # TODO: must define a default value for .source_repository_ref
+source_repository_url: https://github.com/sclorg/rails-ex.git


### PR DESCRIPTION
This pull request adds support for Ruby rails application with no database.

The upstream PR is located here: https://github.com/sclorg/helm-charts/pull/68

The upstream tests passed:

```
test_ruby_imagestreams.py::TestHelmRHELRubyImageStreams::test_package_imagestream[3.1-ubi9-registry.redhat.io/ubi9/ruby-31:latest] [32mPASSED[0m[32m [  8%][0m
test_ruby_imagestreams.py::TestHelmRHELRubyImageStreams::test_package_imagestream[3.1-ubi8-registry.redhat.io/ubi8/ruby-31:latest] [32mPASSED[0m[32m [ 16%][0m
test_ruby_imagestreams.py::TestHelmRHELRubyImageStreams::test_package_imagestream[3.0-ubi9-registry.redhat.io/ubi9/ruby-30:latest] [32mPASSED[0m[32m [ 25%][0m
test_ruby_imagestreams.py::TestHelmRHELRubyImageStreams::test_package_imagestream[3.0-ubi8-registry.redhat.io/ubi8/ruby-30:latest] [32mPASSED[0m[32m [ 33%][0m
test_ruby_imagestreams.py::TestHelmRHELRubyImageStreams::test_package_imagestream[3.0-ubi7-registry.redhat.io/ubi7/ruby-30:latest] [32mPASSED[0m[32m [ 41%][0m
test_ruby_imagestreams.py::TestHelmRHELRubyImageStreams::test_package_imagestream[2.5-ubi8-registry.redhat.io/ubi8/ruby-25:latest] [32mPASSED[0m[32m [ 50%][0m
test_ruby_imagestreams.py::TestHelmCentOSRubyImageStreams::test_package_imagestream[3.0-ubi9-registry.access.redhat.com/ubi9/ruby-30:latest] [32mPASSED[0m[32m [ 58%][0m
test_ruby_imagestreams.py::TestHelmCentOSRubyImageStreams::test_package_imagestream[3.0-ubi8-registry.access.redhat.com/ubi8/ruby-30:latest] [32mPASSED[0m[32m [ 66%][0m
test_ruby_imagestreams.py::TestHelmCentOSRubyImageStreams::test_package_imagestream[3.0-ubi7-registry.access.redhat.com/ubi7/ruby-30:latest] [32mPASSED[0m[32m [ 75%][0m
test_ruby_imagestreams.py::TestHelmCentOSRubyImageStreams::test_package_imagestream[2.5-ubi8-registry.access.redhat.com/ubi8/ruby-25:latest] [32mPASSED[0m[32m [ 83%][0m
test_ruby_rails_application.py::TestHelmRailsTemplate::test_curl_connection [32mPASSED[0m[32m [ 91%][0m
test_ruby_rails_application.py::TestHelmRailsTemplate::test_by_helm_test [32mPASSED[0m[32m [100%][0m

```

Results from helm verify are:
```
results:
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
    - check: v1.0/has-readme
      type: Mandatory
      outcome: PASS
      reason: Chart has a README
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: FAIL
      reason: |-
        ImageCertify() = empty image found
        Image certification skipped : registry.redhat.io/ubi8/ubi:latest
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
```