### PR TITLE
Add nodejs-application without DB

### DIFF
--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/Chart.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: This content is experimental, do not use it in production. An example Node.js application with no database. For more information
+  about using this template, including OpenShift considerations, see https://github.com/sclorg/nodejs-ex/blob/master/README.md.
+name: nodejs-application
+tags: quickstart,nodejs
+version: 0.0.1
+kubeVersion: '>=1.20.0'
+annotations:
+  charts.openshift.io/name: Red Hat Apache Rails application with no database (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.1
+sources:
+  - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/buildconfig.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/buildconfig.yaml
@@ -1,0 +1,40 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    description: Defines how to build the application
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: nodejs-example
+    template: nodejs-example
+  name: {{ .Values.name }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.name }}:latest
+  source:
+    contextDir: {{ .Values.context_dir }}
+    git:
+      ref: {{ .Values.source_repository_ref }}
+      uri: {{ .Values.source_repository_url }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      env:
+      - name: NPM_MIRROR
+        value: {{ .Values.npm_mirror }}
+      from:
+        kind: ImageStreamTag
+        name: nodejs:{{ .Values.nodejs_version }}
+        namespace: {{ .Values.namespace }}
+    type: Source
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange
+  - github:
+      secret: {{ .Values.github_webhook_secret }}
+    type: GitHub
+  - generic:
+      secret: {{ .Values.generic_webhook_secret }}
+    type: Generic

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{ .Values.name }}:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+    template.alpha.openshift.io/wait-for-ready: "true"
+  labels:
+    app: nodejs-example
+    template: nodejs-example
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+      name: {{ .Values.name }}
+    spec:
+      containers:
+      - image: " "
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 3
+        name: nodejs-example
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/imagestream.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/imagestream.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    description: Keeps track of changes in the application image
+  labels:
+    app: nodejs-example
+    template: nodejs-example
+  name: {{ .Values.name }}

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/route.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: nodejs-example
+    template: nodejs-example
+  name: {{ .Values.name }}
+spec:
+  host: {{ .Values.application_domain }}
+  to:
+    kind: Service
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/service.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Exposes and load balances the application pods
+  labels:
+    app: nodejs-example
+    template: nodejs-example
+  name: {{ .Values.name }}
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: {{ .Values.name }}

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/tests/test-nodejs-connection.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/templates/tests/test-nodejs-connection.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.name }}
+    template: {{ .Values.name }}
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-connection-test"
+      image: "registry.redhat.io/ubi8/ubi:latest"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-exc'
+        - >
+          curl {{ .Values.name }}.{{ .Release.Namespace }}:8080 | grep "Node.js Crud Application"
+  restartPolicy: Never

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/values.schema.json
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/values.schema.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string",
+            "title": "The URL of the repository with your application source code."
+        },
+        "nodejs_version": {
+            "type": "string",
+            "description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+            "enum": [ "latest", "18-ubi8", "20-ubi8",  "18-ubi9", "20-ubi9" ]
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Maximum amount of memory the container can use.",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "source_repository_url": {
+            "type": "string"
+        },
+        "source_repository_ref": {
+            "type": "string"
+        },
+        "context_dir": {
+            "type": "string",
+            "description": "Set this to the relative path to your project if it is not in the root of your repository."
+        },
+        "application_domain": {
+            "type": "string",
+            "description": "The exposed hostname that will route to the httpd service, if left blank a value will be defaulted."
+        },
+        "github_webhook_secret": {
+            "type": "string",
+            "description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted."
+        },
+        "generic_webhook_secret": {
+            "type": "string",
+            "description": "A secret string used to configure the Generic webhook."
+        },
+        "npm_mirror": {
+            "type": "string",
+            "description": "The custom NPM mirror URL."
+        }
+    }
+}

--- a/charts/redhat/redhat/nodejs-application/0.0.1/src/values.yaml
+++ b/charts/redhat/redhat/nodejs-application/0.0.1/src/values.yaml
@@ -1,0 +1,11 @@
+application_domain: "" # TODO: must define a default value for .application_domain
+context_dir: "" # TODO: must define a default value for .context_dir
+generic_webhook_secret: "FOO" # TODO: must define a default value for .generic_webhook_secret
+github_webhook_secret: "SOMETHING"# TODO: must define a default value for .github_webhook_secret
+memory_limit: 512Mi
+name: nodejs-example
+namespace: openshift
+nodejs_version: 20-ubi8
+npm_mirror: "" # TODO: must define a default value for .npm_mirror
+source_repository_ref: "master" # TODO: must define a default value for .source_repository_ref
+source_repository_url: https://github.com/sclorg/nodejs-ex.git


### PR DESCRIPTION
Add nodejs-application without DB to openshift-helm-charts/charts repository.

The tests were executed and passed in this pull request. https://github.com/sclorg/helm-charts/pull/72.

The tests executed in upstream repository `helm-charts` have passed.

```
test_nodejs_application.py::TestHelmNodeJSApplication::test_curl_connection [32mPASSED[0m[32m [  4%][0m
test_nodejs_application.py::TestHelmNodeJSApplication::test_by_helm_test [32mPASSED[0m[32m [  9%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[20-ubi9-registry.redhat.io/ubi9/nodejs-20:latest] [32mPASSED[0m[32m [ 13%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[20-ubi9-minimal-registry.redhat.io/ubi9/nodejs-20-minimal:latest] [32mPASSED[0m[32m [ 18%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[20-ubi8-registry.redhat.io/ubi8/nodejs-20:latest] [32mPASSED[0m[32m [ 22%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[20-ubi8-minimal-registry.redhat.io/ubi8/nodejs-20-minimal:latest] [32mPASSED[0m[32m [ 27%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[18-ubi9-registry.redhat.io/ubi9/nodejs-18:latest] [32mPASSED[0m[32m [ 31%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[18-ubi9-minimal-registry.redhat.io/ubi9/nodejs-18-minimal:latest] [32mPASSED[0m[32m [ 36%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[18-ubi8-registry.redhat.io/ubi8/nodejs-18:latest] [32mPASSED[0m[32m [ 40%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[18-ubi8-minimal-registry.redhat.io/ubi8/nodejs-18-minimal:latest] [32mPASSED[0m[32m [ 45%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[16-ubi9-registry.redhat.io/ubi9/nodejs-16:latest] [32mPASSED[0m[32m [ 50%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[16-ubi9-minimal-registry.redhat.io/ubi9/nodejs-16-minimal:latest] [32mPASSED[0m[32m [ 54%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[16-ubi8-registry.redhat.io/ubi8/nodejs-16:latest] [32mPASSED[0m[32m [ 59%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[16-ubi8-minimal-registry.redhat.io/ubi8/nodejs-16-minimal:latest] [32mPASSED[0m[32m [ 63%][0m
test_nodejs_imagestreams.py::TestHelmRHELNodeJSImageStreams::test_package_imagestream[14-ubi7-registry.redhat.io/ubi7/nodejs-14:latest] [32mPASSED[0m[32m [ 68%][0m
test_nodejs_imagestreams.py::TestHelmCentOSNodeJSImageStreams::test_package_imagestream[16-ubi9-registry.access.redhat.com/ubi9/nodejs-16:latest] [32mPASSED[0m[32m [ 72%][0m
test_nodejs_imagestreams.py::TestHelmCentOSNodeJSImageStreams::test_package_imagestream[16-ubi9-minimal-registry.access.redhat.com/ubi9/nodejs-16-minimal:latest] [32mPASSED[0m[32m [ 77%][0m
test_nodejs_imagestreams.py::TestHelmCentOSNodeJSImageStreams::test_package_imagestream[16-ubi8-registry.access.redhat.com/ubi8/nodejs-16:latest] [32mPASSED[0m[32m [ 81%][0m
test_nodejs_imagestreams.py::TestHelmCentOSNodeJSImageStreams::test_package_imagestream[16-ubi8-minimal-registry.access.redhat.com/ubi8/nodejs-16-minimal:latest] [32mPASSED[0m[32m [ 86%][0m
test_nodejs_imagestreams.py::TestHelmCentOSNodeJSImageStreams::test_package_imagestream[14-ubi8-registry.access.redhat.com/ubi8/nodejs-14:latest] [32mPASSED[0m[32m [ 90%][0m
test_nodejs_imagestreams.py::TestHelmCentOSNodeJSImageStreams::test_package_imagestream[14-ubi8-minimal-registry.access.redhat.com/ubi8/nodejs-14-minimal:latest] [32mPASSED[0m[32m [ 95%][0m
test_nodejs_imagestreams.py::TestHelmCentOSNodeJSImageStreams::test_package_imagestream[14-ubi7-registry.access.redhat.com/ubi7/nodejs-14:latest] [32mPASSED[0m[32m [100%][0m
```

The results from verifier are:
```
results:
    - check: v1.0/required-annotations-present
      type: Mandatory
      outcome: PASS
      reason: All required annotations present
    - check: v1.0/contains-test
      type: Mandatory
      outcome: PASS
      reason: Chart test files exist
    - check: v1.0/contains-values-schema
      type: Mandatory
      outcome: PASS
      reason: Values schema file exist
    - check: v1.0/is-helm-v3
      type: Mandatory
      outcome: PASS
      reason: API version is V2, used in Helm 3
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: FAIL
      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
    - check: v1.0/contains-values
      type: Mandatory
      outcome: PASS
      reason: Values file exist
Add nodejs-application without DB to openshift-helm-charts/charts repository.
    - check: v1.1/has-kubeversion
      type: Mandatory
      outcome: PASS
      reason: Kubernetes version specified
    - check: v1.0/not-contain-csi-objects
      type: Mandatory
      outcome: PASS
      reason: CSI objects do not exist
    - check: v1.0/signature-is-valid
      type: Mandatory
      outcome: SKIPPED
      reason: 'Chart is not signed : Signature verification not required'
    - check: v1.0/has-readme
      type: Mandatory
      outcome: FAIL
      reason: Chart does not have a README
    - check: v1.0/helm-lint
      type: Mandatory
      outcome: PASS
      reason: Helm lint successful
    - check: v1.1/images-are-certified
      type: Mandatory
      outcome: FAIL
      reason: |-
        ImageCertify() = empty image found
        Image certification skipped : registry.redhat.io/ubi8/ubi:latest
    - check: v1.0/not-contains-crds
      type: Mandatory
      outcome: PASS
      reason: Chart does not contain CRDs
```