### PR TITLE
Reset providerDelivery bit for intracom-telecom/nfvri

### DIFF
--- a/charts/partners/intracom-telecom/nfvri/OWNERS
+++ b/charts/partners/intracom-telecom/nfvri/OWNERS
@@ -1,8 +1,8 @@
 chart:
   name: nfvri
   shortDescription: NFV-RI (TM) Helm Chart Repository
-providerDelivery: false
-publicPgpKey: unknown
+providerDelivery: true
+publicPgpKey: null
 users:
 - githubUsername: angelouev
 - githubUsername: vaspapts


### PR DESCRIPTION
This PR reverts the modification of the providerDelivery bit that originated in https://github.com/openshift-helm-charts/charts/pull/1370 due to a backend inconsistency.

Unblocks the partner while the inconsistency is addressed.

Case Ref: 03784710