### PR TITLE
Update Remove NodeJS-16 imagestreams. They reached EOL in April 2024

### DIFF
--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/Chart.yaml
@@ -1,0 +1,16 @@
+description: |-
+  This content is experimental, do not use it in production. Build and run NodeJS applications on UBI.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat NodeJS imagestreams (experimental).
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.4
+kubeVersion: '>=1.20.0'
+name: redhat-nodejs-imagestreams
+tags: builder,nodejs
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.4

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/README.md
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/README.md
@@ -1,0 +1,7 @@
+# NodeJS imagestream helm chart
+
+A Helm chart for importing NodeJS imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/templates/nodejs-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/templates/nodejs-imagestream.yaml
@@ -1,0 +1,165 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: nodejs
+  annotations:
+    openshift.io/display-name: Node.js
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Node.js (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      supports: nodejs
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 20-ubi8
+    referencePolicy:
+      type: Local
+  - name: 20-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-20:latest
+    referencePolicy:
+      type: Local
+  - name: 18-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-18:latest
+    referencePolicy:
+      type: Local
+  - name: 20-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-20-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 18-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-18-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 20-ubi8
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-20:latest
+    referencePolicy:
+      type: Local
+  - name: 18-ubi8
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-18:latest
+    referencePolicy:
+      type: Local
+  - name: 20-ubi8-minimal
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 8 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 8 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-20-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 18-ubi8-minimal
+    annotations:
+      openshift.io/display-name: Node.js 18 (UBI 8 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 18 applications on UBI 8 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '18'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-18-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 14-ubi7
+    annotations:
+      openshift.io/display-name: Node.js 14 (UBI 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 14 applications on UBI 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs,hidden
+      version: '14'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi7/nodejs-14:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "nodejs-imagestream-test"
+      image: "registry.access.redhat.com/ubi8/nodejs-20"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          node -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/values.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.4/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: openshift


### PR DESCRIPTION
This pull request removes NodeJS 16 imagestreams as for RHEL8 as for RHEL9.
IThey reached EOL in April 2024