### PR TITLE
Bump version. Remove ubi8/ruby-30 imagestreams. Add ruby-33 imagestreams

### DIFF
--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is experimental, do not use it in production. Ruby imagestreams on UBI.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Ruby imagestreams on UBI (experimental).
+apiVersion: v2
+appVersion: 0.0.2
+kubeVersion: '>=1.20.0'
+name: redhat-ruby-imagestreams
+tags: builder,ruby
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.2

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/Chart.yaml
@@ -5,10 +5,10 @@ description: |-
 annotations:
   charts.openshift.io/name: Red Hat Ruby imagestreams on UBI (experimental).
 apiVersion: v2
-appVersion: 0.0.2
+appVersion: 0.0.3
 kubeVersion: '>=1.20.0'
 name: redhat-ruby-imagestreams
 tags: builder,ruby
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.2
+version: 0.0.3

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/README.md
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/README.md
@@ -1,0 +1,7 @@
+# Ruby imagestreams helm chart
+
+A Helm chart for importing Ruby imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/templates/ruby-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/templates/ruby-imagestream.yaml
@@ -1,0 +1,122 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: ruby
+  annotations:
+    openshift.io/display-name: Ruby
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Ruby (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.0/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 3.0-ubi8
+    referencePolicy:
+      type: Local
+  - name: 3.1-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 3.1 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.1 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.1,ruby
+      version: '3.1'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-31:latest
+    referencePolicy:
+      type: Local
+  - name: 3.0-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 3.0 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.0 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.0,ruby
+      version: '3.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-30:latest
+    referencePolicy:
+      type: Local
+  - name: 3.1-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 3.1 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.1 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.1,ruby
+      version: '3.1'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-31:latest
+    referencePolicy:
+      type: Local
+  - name: 3.0-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 3.0 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.0 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.0,ruby
+      version: '3.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-30:latest
+    referencePolicy:
+      type: Local
+  - name: 3.0-ubi7
+    annotations:
+      openshift.io/display-name: Ruby 3.0 (UBI 7)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.0 applications on UBI 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.0,ruby
+      version: '3.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi7/ruby-30:latest
+    referencePolicy:
+      type: Local
+  - name: 2.5-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 2.5 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 2.5 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:2.5,ruby
+      version: '2.5'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-25:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/templates/ruby-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/templates/ruby-imagestream.yaml
@@ -12,7 +12,7 @@ spec:
       openshift.io/display-name: Ruby (Latest)
       openshift.io/provider-display-name: Red Hat, Inc.
       description: |-
-        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.0/README.md.
+        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.3/README.md.
 
         WARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.
       iconClass: icon-ruby
@@ -21,7 +21,39 @@ spec:
       sampleRepo: https://github.com/sclorg/ruby-ex.git
     from:
       kind: ImageStreamTag
-      name: 3.0-ubi8
+      name: 3.3-ubi9
+    referencePolicy:
+      type: Local
+  - name: 3.3-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 3.3 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.3 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.3,ruby
+      version: '3.3'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-33:latest
+    referencePolicy:
+      type: Local
+  - name: 3.3-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 3.3 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.3 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.3,ruby
+      version: '3.3'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-33:latest
     referencePolicy:
       type: Local
   - name: 3.1-ubi9
@@ -70,22 +102,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.redhat.io/ubi8/ruby-31:latest
-    referencePolicy:
-      type: Local
-  - name: 3.0-ubi8
-    annotations:
-      openshift.io/display-name: Ruby 3.0 (UBI 8)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Ruby 3.0 applications on UBI 8. For more information
-        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
-      iconClass: icon-ruby
-      tags: builder,ruby
-      supports: ruby:3.0,ruby
-      version: '3.0'
-      sampleRepo: https://github.com/sclorg/ruby-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi8/ruby-30:latest
     referencePolicy:
       type: Local
   - name: 3.0-ubi7

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "ruby-imagestream-test"
+      image: "registry.access.redhat.com/ubi9/ruby-31"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          ruby -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/values.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.3/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: openshift


### PR DESCRIPTION
This pull request adds new imagestreams.

ubi8/ruby-33 and ubi9/ruby-33.

ubi8/ruby-30 reached already EOL in Mar 2024