### PR TITLE
EOL pSQL-10 new RHEL-8 and RHEL-9 imagestreams

### DIFF
--- a/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  Red Hat PostgreSQL database service imagestreams.
+  For more information about PostgreSQL container see https://github.com/sclorg/postgresql-container/.
+annotations:
+  charts.openshift.io/name: Red Hat PostgreSQL database service imagestreams.
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: postgresql-imagestreams
+tags: database,postgresql
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/Chart.yaml
@@ -2,12 +2,12 @@ description: |-
   Red Hat PostgreSQL database service imagestreams.
   For more information about PostgreSQL container see https://github.com/sclorg/postgresql-container/.
 annotations:
-  charts.openshift.io/name: Red Hat PostgreSQL database service imagestreams.
+  charts.openshift.io/name: Red Hat PostgreSQL database service imagestreams (experimental)
 apiVersion: v2
-appVersion: 0.0.1
+appVersion: 0.0.2
 kubeVersion: '>=1.20.0'
-name: postgresql-imagestreams
+name: redhat-postgresql-imagestreams
 tags: database,postgresql
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.1
+version: 0.0.2

--- a/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/README.md
+++ b/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/README.md
@@ -1,0 +1,50 @@
+# PostgreSQL Helm Chart imagestreams
+
+The file contains all supported PostgreSQL imagestreams.
+
+For more information about helm charts see the offical [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## How to start with helm charts
+
+The first download and install Helm. Follow instructions mentioned [here](https://helm.sh/docs/intro/install/).
+
+## How to work with PostgreSQL helm chart
+
+Before deploying helm chart to OpenShift, you have to create a package.
+This can be done by command:
+
+```commandline
+$ helm package ./
+```
+
+that will create a helm package named, `postgresql-imagestreams-v0.0.1.tgz` in this directory.
+
+The next step is to upload Helm Chart to OpenShift. This is done by command:
+
+```commandline
+$ helm install postgresql-imagestreams postgresql-imagestreams-v0.0.1.tgz
+```
+
+In order to check if everything is imported properly, run command:
+```commandline
+$ oc get is -o json
+```
+that will print all support PostgreSQL imagestreams.
+
+
+## Troubleshooting
+For case you need a computer readable output you can add to command mentioned above option `-o json`.
+
+In case of installation failed for reason like:
+```commandline
+// Error: INSTALLATION FAILED: cannot re-use a name that is still in use
+```
+you have to uninstall previous PostgreSQL Helm Chart by command:
+
+```commandline
+$ helm uninstall postgresql-imagestreams
+```
+
+

--- a/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/templates/imagestreams.yaml
@@ -1,0 +1,181 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: postgresql
+  annotations:
+    openshift.io/display-name: PostgreSQL
+spec:
+  tags:
+    - name: latest
+      annotations:
+        openshift.io/display-name: PostgreSQL (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL database on RHEL. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of PostgreSQL available on OpenShift,
+          including major version updates.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+      from:
+        kind: ImageStreamTag
+        name: 13-el8
+      referencePolicy:
+        type: Local
+    - name: 13-el9
+      annotations:
+        openshift.io/display-name: PostgreSQL 13 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 13 database on RHEL 9. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '13'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/postgresql-13:latest'
+      referencePolicy:
+        type: Local
+    - name: 13-el8
+      annotations:
+        openshift.io/display-name: PostgreSQL 13 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 13 database on RHEL 8. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '13'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/postgresql-13:latest'
+      referencePolicy:
+        type: Local
+    - name: 13-el7
+      annotations:
+        openshift.io/display-name: PostgreSQL 13 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 13 database on RHEL 7. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '13'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/postgresql-13-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: 12-el8
+      annotations:
+        openshift.io/display-name: PostgreSQL 12 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 12 database on RHEL 8. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '12'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/postgresql-12:latest'
+      referencePolicy:
+        type: Local
+    - name: 12-el7
+      annotations:
+        openshift.io/display-name: PostgreSQL 12 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 12 database on RHEL 7. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '12'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/postgresql-12-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: '12'
+      annotations:
+        openshift.io/display-name: PostgreSQL (Ephemeral) 12
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 12 database on RHEL 7. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql,hidden'
+        version: '12'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/postgresql-12-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: 10-el8
+      annotations:
+        openshift.io/display-name: PostgreSQL 10 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 10 database on RHEL 8. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '10'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/postgresql-10:latest'
+      referencePolicy:
+        type: Local
+    - name: 10-el7
+      annotations:
+        openshift.io/display-name: PostgreSQL 10 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 10 database on RHEL 7. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '10'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/postgresql-10-rhel7:latest'
+      referencePolicy:
+        type: Local
+    - name: '10'
+      annotations:
+        openshift.io/display-name: PostgreSQL (Ephemeral) 10
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 10 database on RHEL 7. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql,hidden'
+        version: '10'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/postgresql-10-rhel7:latest'
+      referencePolicy:
+        type: Local

--- a/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-imagestreams/0.0.2/src/templates/imagestreams.yaml
@@ -23,7 +23,75 @@ spec:
         tags: 'database,postgresql'
       from:
         kind: ImageStreamTag
-        name: 13-el8
+        name: 16-el9
+      referencePolicy:
+        type: Local
+    - name: 16-el9
+      annotations:
+        openshift.io/display-name: PostgreSQL 16 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 16 database on RHEL 9. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '16'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/postgresql-16:latest'
+      referencePolicy:
+        type: Local
+    - name: 16-el8
+      annotations:
+        openshift.io/display-name: PostgreSQL 16 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 16 database on RHEL 8. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '16'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/postgresql-16:latest'
+      referencePolicy:
+        type: Local
+    - name: 15-el9
+      annotations:
+        openshift.io/display-name: PostgreSQL 15 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 15 database on RHEL 9. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '15'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/postgresql-15:latest'
+      referencePolicy:
+        type: Local
+    - name: 15-el8
+      annotations:
+        openshift.io/display-name: PostgreSQL 15 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        description: >-
+          Provides a PostgreSQL 15 database on RHEL 8. For more information
+          about using this database image, including OpenShift considerations,
+          see
+          https://github.com/sclorg/postgresql-container/blob/master/README.md.
+        iconClass: icon-postgresql
+        tags: 'database,postgresql'
+        version: '15'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/postgresql-15:latest'
       referencePolicy:
         type: Local
     - name: 13-el9
@@ -126,23 +194,6 @@ spec:
       from:
         kind: DockerImage
         name: 'registry.redhat.io/rhscl/postgresql-12-rhel7:latest'
-      referencePolicy:
-        type: Local
-    - name: 10-el8
-      annotations:
-        openshift.io/display-name: PostgreSQL 10 (RHEL 8)
-        openshift.io/provider-display-name: 'Red Hat, Inc.'
-        description: >-
-          Provides a PostgreSQL 10 database on RHEL 8. For more information
-          about using this database image, including OpenShift considerations,
-          see
-          https://github.com/sclorg/postgresql-container/blob/master/README.md.
-        iconClass: icon-postgresql
-        tags: 'database,postgresql'
-        version: '10'
-      from:
-        kind: DockerImage
-        name: 'registry.redhat.io/rhel8/postgresql-10:latest'
       referencePolicy:
         type: Local
     - name: 10-el7


### PR DESCRIPTION
Update redhat-postgresql-imagestreams.

RHEL-8 postgresql-10 reached EOL in May 2024

New imagestreams are present.

Postgresql-15 for RHEL8, RHEL9
Postgresql-16 for RHEL8, RHEL9