### PR TITLE
Fix redhat posql persistent

### DIFF
--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/Chart.yaml
@@ -1,0 +1,16 @@
+description: |-
+  This content is expermental, do not use it in production. PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.
+
+  NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
+annotations:
+  charts.openshift.io/name: Red Hat PostgreSQL database service, with persistent storage (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.3
+name: postgresql-persistent
+tags: database,postgresql
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.3
+

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/Chart.yaml
@@ -7,10 +7,10 @@ annotations:
   charts.openshift.io/provider: Red Hat
   charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.3
-name: postgresql-persistent
+appVersion: 0.0.4
+name: redhat-postgresql-persistent
 tags: database,postgresql
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.3
+version: 0.0.4
 

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/README.md
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/README.md
@@ -1,0 +1,23 @@
+# PostgreSQL helm chart
+
+# MariaDB helm chart
+
+A Helm chart for building and deploying a [PostgreSQL](https://github/sclorg/postgresql-container) application on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
+
+## Values
+Below is a table of each value used to configure this chart.
+
+| Value                                       | Description | Default | Additional Information |
+|---------------------------------------------| ----------- | -- | ---------------------- |
+| `database_service_name`                     | The name of the OpenShift Service exposed for the database. | `postgresql` | - |
+| `postgresql_user`                           | Username for PostgreSQL user that will be used for accessing the database. | - | Expresion like: `user[A-Z0-9]{3}` |
+| `postgresql_database`                       | Name of the PostgreSQL database accessed. | `sampledb` |  |
+| `postgresql_password`                       | Password for the PostgreSQL connection user. |  | Expression like: `[a-zA-Z0-9]{16}` |
+| `postgresql_version`                           | Version of PostgreSQL image to be used (10-el7, 10-el8, or latest). | `10-el8` |  |
+| `namespace`                                 | The OpenShift Namespace where the ImageStream resides. | `openshift` | |
+| `memory_limit`                              | Maximum amount of memory the container can use. | `521Mi` |  |
+| `volume_capacity`                           | Volume space available for data, e.g. 512Mi, 2Gi. | `1Gi` |  |

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/deployment.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: "true"
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "postgresql:{{ .Values.image.tag }}"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+  labels:
+    template: postgresql-persistent-template
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.database_service_name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.database_service_name }}
+    spec:
+      containers:
+      - env:
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              key: database-user
+              name: {{ .Values.database_service_name }}
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: database-password
+              name: {{ .Values.database_service_name }}
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database-name
+              name: {{ .Values.database_service_name }}
+        image: " "
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+            - --live
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+        name: "postgresql-persistent"
+        ports:
+        - containerPort: {{ .Values.config.port }}
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: {{ .Values.memory_limit }}
+        securityContext:
+          capabilities: {}
+          privileged: false
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: {{ .Values.database_service_name }}-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - name: {{ .Values.database_service_name }}-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.database_service_name }}
+status: {}

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/persistentvolumeclaim.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    template: postgresql-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volume_capacity }}

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/secret.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+    template.openshift.io/expose-password: '{.data[''database-password'']}'
+    template.openshift.io/expose-username: '{.data[''database-user'']}'
+  labels:
+    template: postgresql-persistent-template
+  name: {{ .Values.database_service_name }}
+stringData:
+  database-name: {{ .Values.config.postgresql_database }}
+  database-password: {{ .Values.config.postgresql_password }}
+  database-user: {{ .Values.config.postgresql_user }}

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/service.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+  labels:
+    template: postgresql-persistent-template
+  name: {{ .Values.database_service_name }}
+spec:
+  ports:
+  - name: postgresql
+    nodePort: 0
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    name: {{ .Values.database_service_name }}
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/tests/test-postgresql-connection.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/templates/tests/test-postgresql-connection.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    name: {{ .Values.database_service_name }}
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "postgresql-connection-test"
+      image: "registry.redhat.io/rhel8/postgresql-13:latest"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: POSTGRESQL_USER
+          value: "{{ .Values.config.postgresql_user }}"
+        - name: PGPASSWORD
+          value: "{{ .Values.config.postgresql_password }}"
+        - name: POSTGRESQL_DATABASE
+          value: "{{ .Values.config.postgresql_database }}"
+        - name: POSTGRESQL_PORT
+          value: "{{ .Values.config.port }}"
+      command:
+        - /bin/bash
+        - -exc
+        - "PGPASSWORD=$PGPASSWORD /usr/bin/pg_isready -d $POSTGRESQL_DATABASE -h {{ .Values.database_service_name }} -p $POSTGRESQL_PORT -U $POSTGRESQL_USER"
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/values.schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "database_service_name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "postgresql_database": {
+                    "type": "string"
+                },
+                "postgresql_password": {
+                    "type": "string"
+                },
+                "postgresql_user": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "volume_capacity": {
+            "type": "string",
+            "title": "Persistent Volume Size",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 1,
+            "sliderMax": 100,
+            "sliderUnit": "Gi"
+        },
+        "memory_limit": {
+            "type": "string",
+            "title": "Database memory limit",
+            "form": true,
+            "render": "slider",
+            "sliderMin": 512,
+            "sliderMax": 65536,
+            "sliderUnit": "Mi"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "tag": {
+                    "type": "string",
+                    "description": "Specify postgresql imagestream tag",
+                    "enum": ["latest", "13-el9", "13-el8", "13-el7", "12-el8", "12-el7", "12", "10-el8", "10-el7", "10" ]
+                }
+            }
+        }
+    }
+}

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/values.schema.json
@@ -50,7 +50,7 @@
                 "tag": {
                     "type": "string",
                     "description": "Specify postgresql imagestream tag",
-                    "enum": ["latest", "13-el9", "13-el8", "13-el7", "12-el8", "12-el7", "12", "10-el8", "10-el7", "10" ]
+                    "enum": ["latest", "16-el9", "16-el8", "15-el9", "15-el8","13-el9", "13-el8", "12-el8", "12" ]
                 }
             }
         }

--- a/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/values.yaml
+++ b/charts/redhat/redhat/redhat-postgresql-persistent/0.0.4/src/values.yaml
@@ -1,0 +1,11 @@
+database_service_name: postgresql-persistent
+memory_limit: 512Mi
+namespace: postgresql-persistent-testing
+volume_capacity: 1Gi
+config:
+  postgresql_database: testdb
+  postgresql_password: testp
+  postgresql_user: testu
+  port: 5432
+image:
+  tag: "13-el8"


### PR DESCRIPTION
This pull request bumps version to 0.0.4

It renames 'postgresql-persistent' name to 'redhat-postgresql-persistent'.

Imagestreams deprecated or 'RHEL7' are removed as well.