### PR TITLE
Add `chatbot-ai-sample` 0.1.5 version

### DIFF
--- a/charts/community/ai-lab/chatbot-ai-sample/0.1.5/report.yaml
+++ b/charts/community/ai-lab/chatbot-ai-sample/0.1.5/report.yaml
@@ -1,0 +1,101 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.13.8
+        profile:
+            VendorType: community
+            version: v1.3
+        reportDigest: uint64:770870434776090047
+        chart-uri: https://github.com/redhat-ai-dev/ai-lab-helm-charts/releases/download/v0.1.5/chatbot-ai-sample-0.1.5.tgz
+        digests:
+            chart: sha256:f41e2487e7b74660368f2742c9b3c4674a125ad6e1dcd7963f108e4173814e7c
+            package: c200cfd45a7d905d80396d39203cc8892c2c4b7a8ab3a5f8c6001b28ffb1a025
+        lastCertifiedTimestamp: "2025-02-05T17:30:50.743167+00:00"
+        testedOpenShiftVersion: "4.15"
+        supportedOpenShiftVersions: '>=4.14'
+        webCatalogOnly: false
+    chart:
+        name: chatbot-ai-sample
+        home: https://github.com/redhat-ai-dev/ai-lab-helm-charts
+        sources:
+            - https://github.com/redhat-ai-dev/ai-lab-template
+        version: 0.1.5
+        description: This Helm Chart deploys a Large Language Model (LLM)-enabled [chat bot application](https://github.com/redhat-ai-dev/ai-lab-samples/tree/main/chatbot).
+        keywords:
+            - chatbot
+            - llama.cpp
+            - ai-lab
+        maintainers:
+            - name: Red Hat AI Development Team
+              email: ""
+              url: https://github.com/redhat-ai-dev
+        icon: ""
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: ""
+        deprecated: false
+        annotations:
+            charts.openshift.io/name: Chatbot AI Sample
+        kubeversion: '>= 1.27.0-0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.1/images-are-certified
+      type: Optional
+      outcome: PASS
+      reason: No images to certify
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/not-contain-csi-objects
+      type: Optional
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/contains-values-schema
+      type: Optional
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/signature-is-valid
+      type: Optional
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified


### PR DESCRIPTION
The PR adds a new version (`0.1.5`) of the `chatbot-ai-sample`, similarly to what we have done in https://github.com/openshift-helm-charts/charts/pull/1670.

I have only added a `report.yaml` from the `chart-verifier` against the package built after our release for https://github.com/redhat-ai-dev/ai-lab-helm-charts