### PR TITLE
Add ai-lab model-server chart owners

### DIFF
--- a/charts/community/ai-lab/model-server/OWNERS
+++ b/charts/community/ai-lab/model-server/OWNERS
@@ -1,0 +1,15 @@
+chart:
+  name: model-server-sample
+  shortDescription: Model Server Sample
+publicPgpKey: null
+users:
+- githubUsername: johnmcollier
+- githubUsername: elsony
+- githubUsername: thepetk
+- githubUsername: michael-valdron
+- githubUsername: yangcao77
+- githubUsername: maysunfaisal
+- githubUsername: Jdubrick
+vendor:
+  label: ai-lab
+  name: AI Development


### PR DESCRIPTION
The PR introduces the new `ai-lab` helm chart - the `model-server` helm chart which deploys a model service based on the values provided by the user.

Once the owners have been added I'll open a new PR to add two new report files, one for chatbot v0.1.6 and one for model-server v0.1.6 chart versions.