### PR TITLE
Update `model-server-sample` chart

### DIFF
--- a/charts/community/ai-lab/model-server-sample/0.1.6/report.yaml
+++ b/charts/community/ai-lab/model-server-sample/0.1.6/report.yaml
@@ -1,0 +1,102 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.13.8
+        profile:
+            VendorType: community
+            version: v1.3
+        reportDigest: uint64:4494372307658540148
+        chart-uri: https://github.com/redhat-ai-dev/ai-lab-helm-charts/releases/download/v0.1.6/model-server-sample-0.1.6.tgz
+        digests:
+            chart: sha256:e9aada8de77b6588a67292ecbfd488d141c77383e9f7bf5f0840969805d10dd2
+            package: 4eb2dbed8c838191941813df8a93ca691d81c828cc0e6df013c96cc2b8a25653
+        lastCertifiedTimestamp: "2025-03-03T16:32:35.310714+00:00"
+        testedOpenShiftVersion: N/A
+        supportedOpenShiftVersions: '>=4.14'
+        webCatalogOnly: false
+    chart:
+        name: model-server-sample
+        home: https://github.com/redhat-ai-dev/ai-lab-helm-charts
+        sources:
+            - https://github.com/redhat-ai-dev/ai-lab-template
+        version: 0.1.6
+        description: This Helm Chart deploys a model server. While no application is configured, this model server can be utilized in other applications.
+        keywords:
+            - modelserver
+            - vllm
+            - llama.cpp
+            - ai-lab
+        maintainers:
+            - name: Red Hat AI Development Team
+              email: ""
+              url: https://github.com/redhat-ai-dev
+        icon: ""
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: ""
+        deprecated: false
+        annotations:
+            charts.openshift.io/name: Model Server Sample
+        kubeversion: '>= 1.27.0-0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/not-contain-csi-objects
+      type: Optional
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/signature-is-valid
+      type: Optional
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.1/images-are-certified
+      type: Optional
+      outcome: PASS
+      reason: No images to certify
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-values-schema
+      type: Optional
+      outcome: PASS
+      reason: Values schema file exist

--- a/charts/community/ai-lab/model-server-sample/0.1.6/report.yaml
+++ b/charts/community/ai-lab/model-server-sample/0.1.6/report.yaml
@@ -1,102 +1,102 @@
 apiversion: v1
 kind: verify-report
 metadata:
-    tool:
-        verifier-version: 1.13.8
-        profile:
-            VendorType: community
-            version: v1.3
-        reportDigest: uint64:4494372307658540148
-        chart-uri: https://github.com/redhat-ai-dev/ai-lab-helm-charts/releases/download/v0.1.6/model-server-sample-0.1.6.tgz
-        digests:
-            chart: sha256:e9aada8de77b6588a67292ecbfd488d141c77383e9f7bf5f0840969805d10dd2
-            package: 4eb2dbed8c838191941813df8a93ca691d81c828cc0e6df013c96cc2b8a25653
-        lastCertifiedTimestamp: "2025-03-03T16:32:35.310714+00:00"
-        testedOpenShiftVersion: N/A
-        supportedOpenShiftVersions: '>=4.14'
-        webCatalogOnly: false
-    chart:
-        name: model-server-sample
-        home: https://github.com/redhat-ai-dev/ai-lab-helm-charts
-        sources:
-            - https://github.com/redhat-ai-dev/ai-lab-template
-        version: 0.1.6
-        description: This Helm Chart deploys a model server. While no application is configured, this model server can be utilized in other applications.
-        keywords:
-            - modelserver
-            - vllm
-            - llama.cpp
-            - ai-lab
-        maintainers:
-            - name: Red Hat AI Development Team
-              email: ""
-              url: https://github.com/redhat-ai-dev
-        icon: ""
-        apiversion: v2
-        condition: ""
-        tags: ""
-        appversion: ""
-        deprecated: false
-        annotations:
-            charts.openshift.io/name: Model Server Sample
-        kubeversion: '>= 1.27.0-0'
-        dependencies: []
-        type: application
-    chart-overrides: ""
+  tool:
+    verifier-version: 1.13.8
+    profile:
+      VendorType: community
+      version: v1.3
+    reportDigest: uint64:8516392735623750647
+    chart-uri: https://github.com/redhat-ai-dev/ai-lab-helm-charts/releases/download/v0.1.6/model-server-sample-0.1.6.tgz
+    digests:
+      chart: sha256:e9aada8de77b6588a67292ecbfd488d141c77383e9f7bf5f0840969805d10dd2
+      package: 4eb2dbed8c838191941813df8a93ca691d81c828cc0e6df013c96cc2b8a25653
+    lastCertifiedTimestamp: "2025-04-28T14:44:05.230189+00:00"
+    testedOpenShiftVersion: "4.16"
+    supportedOpenShiftVersions: ">=4.14"
+    webCatalogOnly: false
+  chart:
+    name: model-server-sample
+    home: https://github.com/redhat-ai-dev/ai-lab-helm-charts
+    sources:
+      - https://github.com/redhat-ai-dev/ai-lab-template
+    version: 0.1.6
+    description: This Helm Chart deploys a model server. While no application is configured, this model server can be utilized in other applications.
+    keywords:
+      - modelserver
+      - vllm
+      - llama.cpp
+      - ai-lab
+    maintainers:
+      - name: Red Hat AI Development Team
+        email: ""
+        url: https://github.com/redhat-ai-dev
+    icon: ""
+    apiversion: v2
+    condition: ""
+    tags: ""
+    appversion: ""
+    deprecated: false
+    annotations:
+      charts.openshift.io/name: Model Server Sample
+    kubeversion: ">= 1.27.0-0"
+    dependencies: []
+    type: application
+  chart-overrides: ""
 results:
-    - check: v1.0/is-helm-v3
-      type: Optional
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/required-annotations-present
-      type: Optional
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.1/has-kubeversion
-      type: Optional
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/not-contain-csi-objects
-      type: Optional
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/not-contains-crds
-      type: Optional
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/has-notes
-      type: Optional
-      outcome: PASS
-      reason: Chart does contain NOTES.txt
-    - check: v1.0/has-readme
-      type: Optional
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/contains-values
-      type: Optional
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/signature-is-valid
-      type: Optional
-      outcome: SKIPPED
-      reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.1/images-are-certified
-      type: Optional
-      outcome: PASS
-      reason: No images to certify
-    - check: v1.0/contains-test
-      type: Optional
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/chart-testing
-      type: Optional
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/contains-values-schema
-      type: Optional
-      outcome: PASS
-      reason: Values schema file exist
+  - check: v1.0/not-contain-csi-objects
+    type: Optional
+    outcome: PASS
+    reason: CSI objects do not exist
+  - check: v1.0/is-helm-v3
+    type: Optional
+    outcome: PASS
+    reason: API version is V2, used in Helm 3
+  - check: v1.0/not-contains-crds
+    type: Optional
+    outcome: PASS
+    reason: Chart does not contain CRDs
+  - check: v1.0/contains-values
+    type: Optional
+    outcome: PASS
+    reason: Values file exist
+  - check: v1.0/contains-test
+    type: Optional
+    outcome: PASS
+    reason: Chart test files exist
+  - check: v1.1/has-kubeversion
+    type: Optional
+    outcome: PASS
+    reason: Kubernetes version specified
+  - check: v1.0/has-readme
+    type: Optional
+    outcome: PASS
+    reason: Chart has a README
+  - check: v1.0/contains-values-schema
+    type: Optional
+    outcome: PASS
+    reason: Values schema file exist
+  - check: v1.0/has-notes
+    type: Optional
+    outcome: PASS
+    reason: Chart does contain NOTES.txt
+  - check: v1.0/required-annotations-present
+    type: Optional
+    outcome: PASS
+    reason: All required annotations present
+  - check: v1.0/chart-testing
+    type: Optional
+    outcome: PASS
+    reason: Chart tests have passed
+  - check: v1.0/signature-is-valid
+    type: Optional
+    outcome: SKIPPED
+    reason: "Chart is not signed : Signature verification not required"
+  - check: v1.1/images-are-certified
+    type: Optional
+    outcome: PASS
+    reason: No images to certify
+  - check: v1.0/helm-lint
+    type: Mandatory
+    outcome: PASS
+    reason: Helm lint successful


### PR DESCRIPTION
First of the two new PRs after I've closed https://github.com/openshift-helm-charts/charts/pull/1744

Adds version 0.1.6 to model-server sample of ai-lab project