### PR TITLE
Add httpd RHEL10 imagestreams to helm charts

### DIFF
--- a/charts/redhat/redhat/redhat-httpd-imagestreams/0.0.3/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-httpd-imagestreams/0.0.3/src/Chart.yaml
@@ -4,10 +4,10 @@ description: |-
 annotations:
   charts.openshift.io/name: Red Hat Apache HTTP Server imagestreams (experimental).
 apiVersion: v2
-appVersion: 0.0.2
+appVersion: 0.0.3
 kubeVersion: '>=1.20.0'
 name: redhat-httpd-imagestreams
 tags: builder,httpd
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.2
+version: 0.0.3

--- a/charts/redhat/redhat/redhat-httpd-imagestreams/0.0.3/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-httpd-imagestreams/0.0.3/src/templates/imagestreams.yaml
@@ -51,6 +51,25 @@ spec:
     - annotations:
         description: >-
           Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          UBI 9. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (UBI 10)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi10/httpd-24:latest'
+      referencePolicy:
+        type: Local
+      name: 2.4-ubi10
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
           RHEL 8. For more information about using this builder image, including
           OpenShift considerations, see
           https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
@@ -67,6 +86,25 @@ spec:
       referencePolicy:
         type: Local
       name: 2.4-ubi8
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 8. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd,hidden'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/rhel8/httpd-24
+      referencePolicy:
+        type: Local
+      name: 2.4-el8
     - annotations:
         description: >-
           Build and serve static content via Apache HTTP Server (httpd) 2.4 on
@@ -93,7 +131,7 @@ spec:
           OpenShift considerations, see
           https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
         iconClass: icon-apache
-        openshift.io/display-name: Apache HTTP Server 2.4 (RHEL 8)
+        openshift.io/display-name: Apache HTTP Server 2.4 (RHEL 10)
         openshift.io/provider-display-name: 'Red Hat, Inc.'
         sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
         supports: httpd
@@ -101,7 +139,7 @@ spec:
         version: '2.4'
       from:
         kind: DockerImage
-        name: registry.redhat.io/rhel8/httpd-24
+        name: registry.redhat.io/rhel10/httpd-24
       referencePolicy:
         type: Local
-      name: 2.4-el8
+      name: 2.4-el10


### PR DESCRIPTION
This pull request adds RHEL10 imagestreams to helm charts.