### PR TITLE
Update OWNERS for redhat-rhaap-self-service-preview chart

### DIFF
--- a/charts/redhat/redhat/redhat-rhaap-self-service-preview/OWNERS
+++ b/charts/redhat/redhat/redhat-rhaap-self-service-preview/OWNERS
@@ -3,6 +3,7 @@ chart:
   shortDescription: "AAP Technical Preview: Self-service automation"
 publicPgpKey: null
 users:
+  - githubUsername: aap-portal-bot
   - githubUsername: abhikdps
   - githubUsername: alisonlhart
   - githubUsername: audgirka


### PR DESCRIPTION
Adds [aap-portal-bot](https://github.com/aap-portal-bot) to our chart's OWNERS list. 