### PR TITLE
EOL PHP-81 RHEL9

### DIFF
--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is experimental, do not use it in production. Import PHP imagestreams to OpenShift 4.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-php-container/blob/master/8.3/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat PHP imagestreams on UBI (experimental)
+apiVersion: v2
+appVersion: 0.0.4
+kubeVersion: '>=1.20.0'
+name: redhat-php-imagestreams
+tags: builder,php
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.4

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/Chart.yaml
@@ -5,10 +5,10 @@ description: |-
 annotations:
   charts.openshift.io/name: Red Hat PHP imagestreams on UBI (experimental)
 apiVersion: v2
-appVersion: 0.0.4
+appVersion: 0.0.5
 kubeVersion: '>=1.20.0'
 name: redhat-php-imagestreams
 tags: builder,php
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.4
+version: 0.0.5

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/README.md
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/README.md
@@ -1,0 +1,7 @@
+# PHP imagestreams helm chart
+
+A Helm chart for importing PHP imagestreams on OpenShift.
+
+For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).
+
+You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/templates/php-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/templates/php-imagestream.yaml
@@ -1,0 +1,138 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: php
+  annotations:
+    openshift.io/display-name: PHP
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: PHP (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run PHP applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.3/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of PHP available on OpenShift, including major version updates.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 8.3-ubi9
+    referencePolicy:
+      type: Local
+  - name: 8.3-ubi10
+    annotations:
+      openshift.io/display-name: PHP 8.3 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.3 applications on UBI 10. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.3/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.3,php
+      version: '8.3'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/php-83:latest
+    referencePolicy:
+      type: Local
+  - name: 8.3-ubi9
+    annotations:
+      openshift.io/display-name: PHP 8.3 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.3 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.3/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.3,php
+      version: '8.3'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/php-83:latest
+    referencePolicy:
+      type: Local
+  - name: 8.2-ubi9
+    annotations:
+      openshift.io/display-name: PHP 8.2 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.2 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.2,php
+      version: '8.2'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/php-82:latest
+    referencePolicy:
+      type: Local
+  - name: 8.2-ubi8
+    annotations:
+      openshift.io/display-name: PHP 8.2 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.2 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.2,php
+      version: '8.2'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/php-82:latest
+    referencePolicy:
+      type: Local
+  - name: 8.1-ubi9
+    annotations:
+      openshift.io/display-name: PHP 8.1 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.1 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.1/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.1,php
+      version: '8.1'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/php-81:latest
+    referencePolicy:
+      type: Local
+  - name: 8.0-ubi9
+    annotations:
+      openshift.io/display-name: PHP 8.0 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.0 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.0,php
+      version: '8.0'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/php-80:latest
+    referencePolicy:
+      type: Local
+  - name: 7.4-ubi8
+    annotations:
+      openshift.io/display-name: PHP 7.4 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 7.4 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.4/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:7.4,php
+      version: '7.4'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/php-74:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/templates/php-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/templates/php-imagestream.yaml
@@ -88,22 +88,6 @@ spec:
       name: registry.redhat.io/ubi8/php-82:latest
     referencePolicy:
       type: Local
-  - name: 8.1-ubi9
-    annotations:
-      openshift.io/display-name: PHP 8.1 (UBI 9)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run PHP 8.1 applications on UBI 9. For more information
-        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.1/README.md.
-      iconClass: icon-php
-      tags: builder,php
-      supports: php:8.1,php
-      version: '8.1'
-      sampleRepo: https://github.com/sclorg/cakephp-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi9/php-81:latest
-    referencePolicy:
-      type: Local
   - name: 8.0-ubi9
     annotations:
       openshift.io/display-name: PHP 8.0 (UBI 9)

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "php-imagestream-test"
+      image: "registry.access.redhat.com/ubi9/php-81"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          php -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/values.schema.json
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/values.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/values.yaml
+++ b/charts/redhat/redhat/redhat-php-imagestreams/0.0.5/src/values.yaml
@@ -1,0 +1,1 @@
+namespace: openshift


### PR DESCRIPTION
The PHP-81 has reached EOL in May 2025.
This deprecates it.