### PR TITLE
Rename redhat-rhaap-portal helm chart and add OWNERS file

### DIFF
--- a/charts/redhat/redhat/redhat-rhaap-portal/OWNERS
+++ b/charts/redhat/redhat/redhat-rhaap-portal/OWNERS
@@ -1,0 +1,13 @@
+chart:
+  name: redhat-rhaap-portal
+  shortDescription: "A Helm chart for deploying a self-service automation portal"
+publicPgpKey: null
+users:
+  - githubUsername: aap-portal-bot
+  - githubUsername: abhikdps
+  - githubUsername: alisonlhart
+  - githubUsername: audgirka
+  - githubUsername: ganeshrn
+vendor:
+  label: redhat
+  name: Red Hat


### PR DESCRIPTION
Makes preparations for the rename from `redhat-rhaap-self-service-preview` chart to `redhat-rhaap-portal` due to the end of preview for this feature.

Adds the OWNERS file. 