### PR TITLE
Add OWNERS file for enclaive/vhsm

### DIFF
--- a/charts/partners/enclaive/vhsm/OWNERS
+++ b/charts/partners/enclaive/vhsm/OWNERS
@@ -1,0 +1,11 @@
+chart:
+  name: vhsm
+  shortDescription: The official enclaive Helm chart for installing and configuring vHSM on OpenShift.
+providerDelivery: false
+publicPgpKey: unknown
+users:
+- githubUsername: klassiker
+- githubUsername: sebastiangajek
+vendor:
+  label: enclaive
+  name: enclaive


### PR DESCRIPTION
This PR adds the OWNERS file for `enclaive/vhsm` per the comment here https://github.com/openshift-helm-charts/charts/pull/2043#issuecomment-3266980127.