### PR TITLE
Add OWNERS file for itrsgroup/iax-operator-crd

### DIFF
--- a/charts/partners/itrsgroup/iax-operator-crd/OWNERS
+++ b/charts/partners/itrsgroup/iax-operator-crd/OWNERS
@@ -1,0 +1,12 @@
+chart:
+  name: iax-operator-crd
+  shortDescription: ITRS Analytics Operator CRD and cluster-scoped resources
+providerDelivery: false
+publicPgpKey: unknown
+users:
+- githubUsername: gjacobitrs
+- githubUsername: talhazubair-itrs
+- githubUsername: jadam-itrs
+vendor:
+  label: itrsgroup
+  name: ITRS Group


### PR DESCRIPTION
## Submission

OWNERS file for **itrsgroup/iax-operator-crd** chart certification.

This registers ITRS Group as the chart owner ahead of the chart + report submission.

Made with [Cursor](https://cursor.com)