### PR TITLE
feat: bootstrap the RHDH must-gather Helm chart [RHIDP-12627]

### DIFF
--- a/charts/redhat/redhat/redhat-developer-hub-must-gather/OWNERS
+++ b/charts/redhat/redhat/redhat-developer-hub-must-gather/OWNERS
@@ -4,6 +4,10 @@ chart:
 publicPgpKey: null
 users:
   - githubUsername: rhdh-bot
+  - githubUsername: josephca
+  - githubUsername: polasudo
+  - githubUsername: nickboldt
+  - githubUsername: rm3l
 vendor:
   label: redhat
   name: Red Hat

--- a/charts/redhat/redhat/redhat-developer-hub-must-gather/OWNERS
+++ b/charts/redhat/redhat/redhat-developer-hub-must-gather/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: redhat-developer-hub-must-gather
+  shortDescription: A Helm chart for running the Red Hat Developer Hub Must Gather tool
+publicPgpKey: null
+users:
+  - githubUsername: rhdh-bot
+vendor:
+  label: redhat
+  name: Red Hat

--- a/charts/redhat/redhat/redhat-developer-hub-must-gather/OWNERS
+++ b/charts/redhat/redhat/redhat-developer-hub-must-gather/OWNERS
@@ -7,7 +7,6 @@ users:
   - githubUsername: josephca
   - githubUsername: polasudo
   - githubUsername: nickboldt
-  - githubUsername: rm3l
 vendor:
   label: redhat
   name: Red Hat


### PR DESCRIPTION
Bootstrap the upcoming RHDH must-gather chart with an `OWNERS` file.

Fixes https://redhat.atlassian.net/browse/RHIDP-12627