### PR TITLE
chore: update OWNERS file for RHDH orchestrator-infra chart

### DIFF
--- a/charts/redhat/redhat/redhat-developer-hub-orchestrator-infra/OWNERS
+++ b/charts/redhat/redhat/redhat-developer-hub-orchestrator-infra/OWNERS
@@ -4,6 +4,9 @@ chart:
 publicPgpKey: null
 users:
   - githubUsername: rhdh-bot
+  - githubUsername: josephca
+  - githubUsername: polasudo
+  - githubUsername: nickboldt
 vendor:
   label: redhat
   name: Red Hat

--- a/charts/redhat/redhat/redhat-developer-hub-orchestrator-infra/OWNERS
+++ b/charts/redhat/redhat/redhat-developer-hub-orchestrator-infra/OWNERS
@@ -4,10 +4,6 @@ chart:
 publicPgpKey: null
 users:
   - githubUsername: rhdh-bot
-  - githubUsername: nickboldt
-  - githubUsername: kadel
-  - githubUsername: rm3l
-  - githubUsername: Fortune-Ndlovu
 vendor:
   label: redhat
   name: Red Hat


### PR DESCRIPTION
Doing so as we always push PRs as the rhdh-bot users
