### PR TITLE
Add initial owners for the OpenBao community charts

### DIFF
--- a/charts/community/openbao/openbao/OWNERS
+++ b/charts/community/openbao/openbao/OWNERS
@@ -1,0 +1,13 @@
+chart:
+  name: openbao
+  shortDescription: OpenBao is an open source, community-driven fork of Vault managed by the Linux Foundation.
+publicPgpKey: null
+providerDelivery: False
+users:
+  - githubUsername: eyenx
+  - githubUsername: karras
+  - githubUsername: Nerkho
+  - githubUsername: pree
+vendor:
+  label: openbao
+  name: OpenBao


### PR DESCRIPTION
This adds the initial OWNERS file in order to then contribute the OpenBao Helm chart.

cc @eyenx, @Nerkho, @pree