### PR TITLE
Add OWNERS file for kubesense helm chart certification

### DIFF
--- a/charts/partners/kubesense/kubesense/OWNERS
+++ b/charts/partners/kubesense/kubesense/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: kubesense
+  shortDescription: Kubesense Helm chart for APM, Logs, and Infrastructure Monitoring
+providerDelivery: false
+publicPgpKey: unknown
+users:
+- githubUsername: saurabhkaveri-03
+vendor:
+  label: kubesense
+  name: Kubesense, Inc.


### PR DESCRIPTION
Adding OWNERS file to register as a certified partner for the kubesense Helm chart.