### PR TITLE
Add new owners to Vault chart

### DIFF
--- a/charts/partners/hashicorp/vault/OWNERS
+++ b/charts/partners/hashicorp/vault/OWNERS
@@ -9,6 +9,8 @@ users:
 - githubUsername: benashz
 - githubUsername: digivava
 - githubUsername: tomcf-hcp
+- githubUsername: vijayavelsekar
+- githubUsername: siyer-corp
 vendor:
   label: hashicorp
   name: HashiCorp


### PR DESCRIPTION
Add Github users to the owners file to support Red Hat access for submitting OpenShift artifacts