### PR TITLE
Request to add Vault engineers to owners for PR purposes

### DIFF
--- a/charts/partners/hashicorp/vault/OWNERS
+++ b/charts/partners/hashicorp/vault/OWNERS
@@ -9,6 +9,8 @@ users:
 - githubUsername: benashz
 - githubUsername: digivava
 - githubUsername: tomcf-hcp
+- githubUsername: vijayavelsekar
+- githubUsername: siyer-corp
 vendor:
   label: hashicorp
   name: HashiCorp


### PR DESCRIPTION
Vijayavel Sekar  [9:36 PM]
Hi [@Jesse Kaufman](https://ibm.enterprise.slack.com/team/U08G2UH35QT)
1) Vault Secrets Operator(VSO):
We need a Red Hat account with the ability to make PRs against Red Hat’s certified operators repo https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main

2) Vault Helm:
We need our GitHub user id added to the [OWNERS file](https://github.com/openshift-helm-charts/charts/blob/main/charts/partners/hashicorp/vault/OWNERS) in the Openshift helm repository.
For now, you can add below id's

vijayavelsekar
siyer-corp