### PR TITLE
Add verification report for community chart camel-dashboard-openshift-all 4.21.2

### DIFF
--- a/charts/community/camel-tooling/camel-dashboard-openshift-all/4.21.2/report.yaml
+++ b/charts/community/camel-tooling/camel-dashboard-openshift-all/4.21.2/report.yaml
@@ -1,0 +1,129 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.15.0
+        profile:
+            VendorType: community
+            version: v1.3
+        reportDigest: uint64:14415958752992964818
+        chart-uri: https://camel-tooling.github.io/camel-dashboard/charts/camel-dashboard-openshift-all-4.21.2.tgz
+        digests:
+            chart: sha256:25fa55f2184d7590c0dfdfd29de78135e9c4a89c63597cf7a6363e4e8ffc6ce3
+            package: 3823df5d76d364d9de8a178f2cfed6c9bf4db1c5e3c63d229c602638d7f7d222
+        lastCertifiedTimestamp: "2026-06-03T16:39:24.210258+02:00"
+        testedOpenShiftVersion: "4.21"
+        supportedOpenShiftVersions: '>=4.21'
+        webCatalogOnly: false
+    chart:
+        name: camel-dashboard-openshift-all
+        home: https://camel-tooling.github.io/camel-dashboard/
+        sources:
+            - https://github.com/camel-tooling/camel-dashboard
+            - https://github.com/camel-tooling/camel-monitor-operator
+            - https://github.com/camel-tooling/camel-dashboard-console
+            - https://github.com/hawtio/hawtio-online
+        version: 4.21.2
+        description: Helm umbrella chart for Camel Dashboard on OpenShift
+        keywords:
+            - camel
+            - dashboard
+            - operator
+            - console
+            - integration
+            - hawtio
+            - jolokia
+            - jmx
+            - openshift
+        maintainers:
+            - name: gfournier
+              email: gfournier@apache.org
+              url: ""
+        icon: https://raw.githubusercontent.com/camel-tooling/camel-dashboard-openshift-all/refs/heads/main/icons/logo.png
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: ""
+        deprecated: false
+        annotations:
+            charts.openshift.io/name: Camel Dashboard on OpenShift
+        kubeversion: '>= 1.34'
+        dependencies:
+            - name: camel-monitor-operator
+              version: 0.2.1
+              repository: https://camel-tooling.github.io/camel-dashboard/charts
+              condition: camel-monitor-operator.enabled
+            - name: camel-dashboard-console
+              version: 0.5.0
+              repository: https://camel-tooling.github.io/camel-dashboard/charts
+              condition: camel-dashboard-console.enabled
+            - name: hawtio-online-console-plugin
+              version: 0.7.0
+              repository: https://hawtio.github.io/hawtio-charts
+              condition: hawtio-online-console-plugin.enabled
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/not-contain-csi-objects
+      type: Optional
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.1/images-are-certified
+      type: Optional
+      outcome: FAIL
+      reason: |-
+        Image is not Red Hat certified : quay.io/camel-tooling/camel-monitor-operator:0.2.1
+        Image is not Red Hat certified : quay.io/hawtio/online-console-plugin-gateway:0.7.0
+        Image is not Red Hat certified : quay.io/hawtio/online-console-plugin:0.7.0
+        Image is Red Hat certified : registry.access.redhat.com/ubi9/ubi-minimal:9.4
+        Image certification skipped : registry.redhat.io/openshift4/ose-tools-rhel9@sha256:ee65b244fc94d5765514c604dc0a288517dcdce68de65128d047622b6b30a618
+        Image certification skipped : registry.redhat.io/openshift4/ose-tools-rhel8@sha256:e44074f21e0cca6464e50cb6ff934747e0bd11162ea01d522433a1a1ae116103
+        Image is not Red Hat certified : quay.io/camel-tooling/camel-dashboard-console:0.5.0
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: FAIL
+      reason: Chart contains CRDs
+    - check: v1.0/signature-is-valid
+      type: Optional
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values-schema
+      type: Optional
+      outcome: FAIL
+      reason: Values schema file does not exist


### PR DESCRIPTION
Adding upgrade for OCP 4.21.

Report generated with `chart-verifier --chart-set "hawtio-online-console-plugin.mockProxySecret"=true --set profile.vendorType=community verify https://camel-tooling.github.io/camel-dashboard/charts/camel-dashboard-openshift-all-4.21.1.tgz --write-to-file`