### PR TITLE
Add OWNERS files for ZCM charts (web catalog only, providerDelivery: true)

### DIFF
--- a/charts/partners/iwhalecloud/zcm-application/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-application/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-application
+  shortDescription: ZCM Application Service
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-cmdb/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-cmdb/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-cmdb
+  shortDescription: ZCM Configuration Management Database
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-healthkeeper/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-healthkeeper/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-healthkeeper
+  shortDescription: ZCM HealthKeeper - Health monitoring for ZCM platform
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-image/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-image/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-image
+  shortDescription: ZCM Image Management
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-mysql/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-mysql/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-mysql
+  shortDescription: ZCM MySQL Database Chart
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-portal/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-portal/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-portal
+  shortDescription: ZCM Portal Management Component
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-redis/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-redis/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-redis
+  shortDescription: ZCM Redis Cache Chart
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-resource/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-resource/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-resource
+  shortDescription: ZCM Resource Management
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-service/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-service/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-service
+  shortDescription: ZCM Service Governance
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.

--- a/charts/partners/iwhalecloud/zcm-ssc/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-ssc/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-ssc
+  shortDescription: ZCM Shared Services Component
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.


### PR DESCRIPTION
Adding OWNERS files for 10 ZCM Helm charts. Delivery method: Web catalog only (providerDelivery: true).

Charts:
- zcm-cmdb
- zcm-portal
- zcm-mysql
- zcm-redis
- zcm-healthkeeper
- zcm-application
- zcm-image
- zcm-resource
- zcm-service
- zcm-ssc