### PR TITLE
Add OWNERS file for zcm-cmdb (web catalog only, providerDelivery: true)

### DIFF
--- a/charts/partners/iwhalecloud/zcm-cmdb/OWNERS
+++ b/charts/partners/iwhalecloud/zcm-cmdb/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: zcm-cmdb
+  shortDescription: ZCM Configuration Management Database
+publicPgpKey: null
+providerDelivery: true
+users:
+  - githubUsername: Mredward123
+vendor:
+  label: iwhalecloud
+  name: Whale Cloud Singapore Pte. Ltd.


### PR DESCRIPTION
Adding OWNERS file for zcm-cmdb. Delivery method: Web catalog only (providerDelivery: true).