### PR TITLE
Submit zcm-cmdb 0.1.0 for certification (web catalog only, providerDelivery: true)

### DIFF
--- a/charts/partners/iwhalecloud/zcm-cmdb/0.1.0/report.yaml
+++ b/charts/partners/iwhalecloud/zcm-cmdb/0.1.0/report.yaml
@@ -1,0 +1,92 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.14.1
+        profile:
+            VendorType: partner
+            version: v1.3
+        reportDigest: uint64:15156381224272682906
+        chart-uri: N/A
+        digests:
+            chart: sha256:ab0dd271169b5581d6f1291cdf14071501b18565d2ea6d1b063c0f5ea42188e7
+            package: 9e6f072dde7a40181e0aaee59343fd39e377f8ee8f96e4155e037b4aee151fab
+            publicKey: 1d8bb3e379cd7100bd5183393457b7f20f7dac1be1829654d95dcac9fbaf3650
+        lastCertifiedTimestamp: "2026-06-08T14:48:29.696286+08:00"
+        testedOpenShiftVersion: "4.20"
+        supportedOpenShiftVersions: '>=4.7'
+        webCatalogOnly: true
+    chart:
+        name: zcm-cmdb
+        home: ""
+        sources: []
+        version: 0.1.0
+        description: A Helm chart for Kubernetes
+        keywords: []
+        maintainers: []
+        icon: ""
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: aik
+        deprecated: false
+        annotations:
+            charts.openshift.io/name: zcm-cmdb
+        kubeversion: '>=1.20.0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: PASS
+      reason: 'Chart is signed : Signature verification passed'
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+


### PR DESCRIPTION
## Summary

Submit **zcm-cmdb 0.1.0** for Red Hat OpenShift Helm Chart certification.

**Delivery method:** Web catalog only (providerDelivery: true)

## Files

- `zcm-cmdb-0.1.0.tgz` — Helm chart tarball
- `report.yaml` — chart-verifier verification report (generated with `--web-catalog-only`)

## Chart Details

| Field | Value |
|-------|-------|
| Chart Name | zcm-cmdb |
| Version | 0.1.0 |
| Vendor | iwhalecloud |
| Description | ZCM Configuration Management Database |
| Tested OpenShift Version | 4.20 |
| Supported OpenShift Versions | >= 4.7 |

## Checklist

- [x] OWNERS file exists at `charts/partners/iwhalecloud/zcm-cmdb/OWNERS`
- [x] `providerDelivery: true` set in OWNERS
- [x] Report generated with `--web-catalog-only` flag
- [x] Report includes all mandatory checks: PASS
- [x] Chart digest matches report digest