### PR TITLE
Submit zcm-application 0.1.0 verification report (web catalog only)

### DIFF
--- a/charts/partners/iwhalecloud/zcm-application/0.1.0/report.yaml
+++ b/charts/partners/iwhalecloud/zcm-application/0.1.0/report.yaml
@@ -1,0 +1,92 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.14.1
+        profile:
+            VendorType: partner
+            version: v1.3
+        reportDigest: uint64:1170858996979226631
+        chart-uri: N/A
+        digests:
+            chart: sha256:8c7dd6adc5ee54eb9456a68b91720db3e9c05932439e1a92a88bd5a1740437bf
+            package: 5304313f70484eb28b6d10264adee8f8b67fba562b145401f8587d3a96972c38
+            publicKey: 1d8bb3e379cd7100bd5183393457b7f20f7dac1be1829654d95dcac9fbaf3650
+        lastCertifiedTimestamp: "2026-06-08T15:25:34.922447+08:00"
+        testedOpenShiftVersion: "4.20"
+        supportedOpenShiftVersions: '>=4.7'
+        webCatalogOnly: true
+    chart:
+        name: zcm-application
+        home: ""
+        sources: []
+        version: 0.1.0
+        description: A Helm chart for Kubernetes
+        keywords: []
+        maintainers: []
+        icon: ""
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: aik
+        deprecated: false
+        annotations:
+            charts.openshift.io/name: zcm-application
+        kubeversion: '>=1.20.0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: PASS
+      reason: 'Chart is signed : Signature verification passed'
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+


### PR DESCRIPTION
Submitting zcm-application 0.1.0 verification report for Red Hat OpenShift certification.

**Delivery method:** Web catalog only (providerDelivery: true)
**File:** report.yaml (generated with `--web-catalog-only`)