### PR TITLE
Add zcm-redis 0.1.0 verification report

### DIFF
--- a/charts/partners/iwhalecloud/zcm-redis/0.1.0/report.yaml
+++ b/charts/partners/iwhalecloud/zcm-redis/0.1.0/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.3
-        reportDigest: uint64:11506990529405218537
+        reportDigest: uint64:8440614228156750125
         chart-uri: N/A
         digests:
             chart: sha256:6167866b735b83d9531d0fecd2b7b28918ef824193a61234aa3b7888526697da
-            package: ba06594a90faff9fbecfef1d3e2df0365c3b1e3aad9473c96fdd5062841620c4
+            package: 05be7dee01cd2c31e9db8e4b1ced9b6bb22bf0a07bbc004d37f1fb35094afb3a
             publicKey: a379619cb95e0e26d7bf356b65e160fa53b6f36b41f137e3d49595ff75416be7
-        lastCertifiedTimestamp: "2026-06-10T01:58:08.245858+00:00"
+        lastCertifiedTimestamp: "2026-06-10T03:04:08.239914+00:00"
         testedOpenShiftVersion: "4.21"
         supportedOpenShiftVersions: '>=4.7'
         webCatalogOnly: true
@@ -37,22 +37,18 @@ metadata:
         type: application
     chart-overrides: ""
 results:
-    - check: v1.0/helm-lint
+    - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/is-helm-v3
+      reason: Chart does not contain CRDs
+    - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: PASS
-      reason: API version is V2, used in Helm 3
+      reason: 'Chart is signed : Signature verification passed'
     - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
       reason: Chart test files exist
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
@@ -61,26 +57,18 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Chart has a README
-    - check: v1.0/has-notes
-      type: Optional
-      outcome: PASS
-      reason: Chart does contain NOTES.txt
-    - check: v1.0/not-contains-crds
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: FAIL
+      reason: 'Failed to certify images : 10.10.194.210:52800/zcm9/redis:8.2.3.1 : Get "https://catalog.redhat.com/api/containers/v1/repositories/registry/10.10.194.210:52800/repository/zcm9/redis/images?filter=repositories%3Dem%3D%28repository%3D%3Dzcm9%2Fredis%3Bregistry%3D%3D10.10.194.210%3A52800%29&page=0&page_size=100": dial tcp 223.113.13.96:443: i/o timeout'
+    - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
-      reason: Chart does not contain CRDs
+      reason: CSI objects do not exist
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/signature-is-valid
-      type: Mandatory
-      outcome: PASS
-      reason: 'Chart is signed : Signature verification passed'
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
@@ -89,4 +77,20 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
 

--- a/charts/partners/iwhalecloud/zcm-redis/0.1.0/report.yaml
+++ b/charts/partners/iwhalecloud/zcm-redis/0.1.0/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.3
-        reportDigest: uint64:827655629638909422
+        reportDigest: uint64:11506990529405218537
         chart-uri: N/A
         digests:
             chart: sha256:6167866b735b83d9531d0fecd2b7b28918ef824193a61234aa3b7888526697da
-            package: a46ab6b27e2e50a7bd2c418244b6cbfc9aae7fb86ebbcb218ea9abc36735b89d
-            publicKey: faddde9322d270f37e3defdc58318d92faafce803bd6494aa1ae25db8c09f3e5
-        lastCertifiedTimestamp: "2026-06-09T08:01:10.43254+00:00"
+            package: ba06594a90faff9fbecfef1d3e2df0365c3b1e3aad9473c96fdd5062841620c4
+            publicKey: a379619cb95e0e26d7bf356b65e160fa53b6f36b41f137e3d49595ff75416be7
+        lastCertifiedTimestamp: "2026-06-10T01:58:08.245858+00:00"
         testedOpenShiftVersion: "4.21"
         supportedOpenShiftVersions: '>=4.7'
         webCatalogOnly: true
@@ -37,6 +37,22 @@ metadata:
         type: application
     chart-overrides: ""
 results:
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
@@ -45,26 +61,26 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Chart has a README
-    - check: v1.0/helm-lint
-      type: Mandatory
+    - check: v1.0/has-notes
+      type: Optional
       outcome: PASS
-      reason: Helm lint successful
+      reason: Chart does contain NOTES.txt
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/contains-test
+    - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: PASS
-      reason: Chart test files exist
+      reason: 'Chart is signed : Signature verification passed'
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
@@ -73,20 +89,4 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Values file exist
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/has-notes
-      type: Optional
-      outcome: PASS
-      reason: Chart does contain NOTES.txt
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/signature-is-valid
-      type: Mandatory
-      outcome: PASS
-      reason: 'Chart is signed : Signature verification passed'
 

--- a/charts/partners/iwhalecloud/zcm-redis/0.1.0/report.yaml
+++ b/charts/partners/iwhalecloud/zcm-redis/0.1.0/report.yaml
@@ -1,0 +1,92 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.14.1
+        profile:
+            VendorType: partner
+            version: v1.3
+        reportDigest: uint64:827655629638909422
+        chart-uri: N/A
+        digests:
+            chart: sha256:6167866b735b83d9531d0fecd2b7b28918ef824193a61234aa3b7888526697da
+            package: a46ab6b27e2e50a7bd2c418244b6cbfc9aae7fb86ebbcb218ea9abc36735b89d
+            publicKey: faddde9322d270f37e3defdc58318d92faafce803bd6494aa1ae25db8c09f3e5
+        lastCertifiedTimestamp: "2026-06-09T08:01:10.43254+00:00"
+        testedOpenShiftVersion: "4.21"
+        supportedOpenShiftVersions: '>=4.7'
+        webCatalogOnly: true
+    chart:
+        name: zcm-redis
+        home: ""
+        sources: []
+        version: 0.1.0
+        description: A Helm chart for Kubernetes
+        keywords: []
+        maintainers: []
+        icon: ""
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: aik
+        deprecated: false
+        annotations:
+            charts.openshift.io/name: zcm-redis
+        kubeversion: '>=1.20.0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: PASS
+      reason: 'Chart is signed : Signature verification passed'
+


### PR DESCRIPTION
## Chart Information

| Field | Value |
|-------|-------|
| **Chart Name** | zcm-redis |
| **Version** | 0.1.0 |
| **Vendor** | iWhaleCloud |
| **Type** | application |
| **App Version** | aik |
| **Kube Version** | >=1.20.0 |

## Verification Details

| Field | Value |
|-------|-------|
| **Tool Version** | chart-verifier v1.14.1 |
| **Profile** | v1.3 / partner |
| **Tested OpenShift Version** | 4.21 |
| **Supported OpenShift Versions** | >=4.7 |
| **Web Catalog Only** | true |
| **Certified Timestamp** | 2026-06-09T08:01:10+00:00 |

## Verification Results

All Mandatory checks passed: ✅

## Delivery Method

- Web catalog only delivery (no chart tarball submitted)
- Chart is signed, PGP public key registered in OWNERS file