### PR TITLE
Add zcm-image 0.1.0 chart with verifier report

### DIFF
--- a/charts/partners/iwhalecloud/zcm-image/0.1.0/report.yaml
+++ b/charts/partners/iwhalecloud/zcm-image/0.1.0/report.yaml
@@ -1,0 +1,98 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.14.1
+        profile:
+            VendorType: partner
+            version: v1.3
+        reportDigest: uint64:14970414161784070819
+        chart-uri: N/A
+        digests:
+            chart: sha256:0959c1f5468fc9b3c697e2e415c0b7ad1b1931cfd39fe9a79691b55304d505c5
+            package: 0c374a79cc436315ea6f42737bde5d643faf377745864f160b0cb88f8c9c0b58
+            publicKey: e80ff9a88c0e9a3495a8db06b1da25266a953ef2059342a01891652599d7c719
+        lastCertifiedTimestamp: "2026-06-10T17:40:21.173392+08:00"
+        testedOpenShiftVersion: "4.21"
+        supportedOpenShiftVersions: '>=4.7'
+        webCatalogOnly: true
+    chart:
+        name: zcm-image
+        home: ""
+        sources: []
+        version: 0.1.0
+        description: A Helm chart for Kubernetes
+        keywords: []
+        maintainers: []
+        icon: ""
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: aik
+        deprecated: false
+        annotations:
+            charts.openshift.io/name: zcm-image
+        kubeversion: '>=1.20.0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: PASS
+      reason: 'Chart is signed : Signature verification passed'
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: FAIL
+      reason: |-
+        Failed to certify images : 10.10.194.210:52800/zcm9/zcm-image:C_20260311112012 : Get "https://catalog.redhat.com/api/containers/v1/repositories/registry/10.10.194.210:52800/repository/zcm9/zcm-image/images?filter=repositories%3Dem%3D%28repository%3D%3Dzcm9%2Fzcm-image%3Bregistry%3D%3D10.10.194.210%3A52800%29&page=0&page_size=100": dial tcp [2409:8c20:5a63:13::249c:5031]:443: connect: no route to host
+        Failed to certify images : 10.10.194.210:52800/zcm9/redis:8.2.3.1 : Get "https://catalog.redhat.com/api/containers/v1/repositories/registry/10.10.194.210:52800/repository/zcm9/redis/images?filter=repositories%3Dem%3D%28repository%3D%3Dzcm9%2Fredis%3Bregistry%3D%3D10.10.194.210%3A52800%29&page=0&page_size=100": dial tcp [2409:8c20:5a63:13::249c:5031]:443: connect: no route to host
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+


### PR DESCRIPTION
```markdown
## Description

Add zcm-image helm chart version 0.1.0 with chart-verifier report.

## Chart Details

- **Chart Name**: zcm-image
- **Version**: 0.1.0
- **Vendor**: iwhalecloud
- **Category**: partners

## Submission Content

This PR adds the following files:

```
charts/partners/iwhalecloud/zcm-image/
├── OWNERS # (synced from upstream)
└── 0.1.0/
    └── report.yaml           # Chart-verifier verification report
```

## Verification

- [x] Chart-verifier validation passed
- [x] Report generated using: `chart-verifier verify --output yaml`
- [x] Report is within 24 hours of generation

## Notes

- This chart submission is independent of other open PRs (zcm-redis, zcm-resource)
- No dependencies between charts
- Ready for review

## Checklist

- [x] Chart follows partners guidelines
- [x] OWNERS file is present
- [x] report.yaml is generated by chart-verifier
- [x] No sensitive data in chart
```