### PR TITLE
Update nginx imagestreams

### DIFF
--- a/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  This content is experimental, do not use it in production. Build and serve static content via Nginx HTTP server
+  and a reverse proxy (nginx) on RHEL. https://github.com/sclorg/nginx-container/blob/master/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Nginx HTTP server and a reverse proxy (nginx) (experimental)
+apiVersion: v2
+appVersion: 0.0.3
+kubeVersion: '>=1.20.0'
+name: redhat-nginx-imagestreams
+tags: builder,nginx
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.3

--- a/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/Chart.yaml
@@ -3,11 +3,13 @@ description: |-
   and a reverse proxy (nginx) on RHEL. https://github.com/sclorg/nginx-container/blob/master/README.md.
 annotations:
   charts.openshift.io/name: Red Hat Nginx HTTP server and a reverse proxy (nginx) (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.3
+appVersion: 0.0.4
 kubeVersion: '>=1.20.0'
 name: redhat-nginx-imagestreams
 tags: builder,nginx
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.3
+version: 0.0.4

--- a/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/templates/imagestreams.yaml
@@ -1,0 +1,164 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Nginx HTTP server and a reverse proxy (nginx)
+  name: nginx
+spec:
+  tags:
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of Nginx available on OpenShift,
+          including major version updates.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+      from:
+        kind: ImageStreamTag
+        name: 1.26-ubi9
+      referencePolicy:
+        type: Local
+      name: latest
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 10. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.26 (UBI 10)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.26'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi10/nginx-126:latest'
+      referencePolicy:
+        type: Local
+      name: 1.26-ubi10
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 9. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.26 (UBI 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.26'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi9/nginx-126:latest'
+      referencePolicy:
+        type: Local
+      name: 1.26-ubi9
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 9. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.24 (UBI 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.22'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi9/nginx-124:latest'
+      referencePolicy:
+        type: Local
+      name: 1.24-ubi9
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 8. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.24 (UBI 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.24'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi8/nginx-124:latest'
+      referencePolicy:
+        type: Local
+      name: 1.24-ubi8
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 9. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.22 (UBI 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.22'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi9/nginx-122:latest'
+      referencePolicy:
+        type: Local
+      name: 1.22-ubi9
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 8. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.22 (UBI 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.22'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi8/nginx-122:latest'
+      referencePolicy:
+        type: Local
+      name: 1.22-ubi8
+    - annotations:
+        description: >-
+          Build and serve static content via Nginx HTTP server and a reverse
+          proxy (nginx) on RHEL 8. For more information about using this builder
+          image, including OpenShift considerations, see
+          https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.
+        iconClass: icon-nginx
+        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.20 (UBI 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
+        supports: nginx
+        tags: 'builder,nginx'
+        version: '1.20'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi9/nginx-120:latest'
+      referencePolicy:
+        type: Local
+      name: 1.20-ubi9

--- a/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-nginx-imagestreams/0.0.4/src/templates/imagestreams.yaml
@@ -79,7 +79,7 @@ spec:
         sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
         supports: nginx
         tags: 'builder,nginx'
-        version: '1.22'
+        version: '1.24'
       from:
         kind: DockerImage
         name: 'registry.redhat.io/ubi9/nginx-124:latest'
@@ -109,44 +109,6 @@ spec:
         description: >-
           Build and serve static content via Nginx HTTP server and a reverse
           proxy (nginx) on RHEL 9. For more information about using this builder
-          image, including OpenShift considerations, see
-          https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.
-        iconClass: icon-nginx
-        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.22 (UBI 9)
-        openshift.io/provider-display-name: 'Red Hat, Inc.'
-        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
-        supports: nginx
-        tags: 'builder,nginx'
-        version: '1.22'
-      from:
-        kind: DockerImage
-        name: 'registry.redhat.io/ubi9/nginx-122:latest'
-      referencePolicy:
-        type: Local
-      name: 1.22-ubi9
-    - annotations:
-        description: >-
-          Build and serve static content via Nginx HTTP server and a reverse
-          proxy (nginx) on RHEL 8. For more information about using this builder
-          image, including OpenShift considerations, see
-          https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.
-        iconClass: icon-nginx
-        openshift.io/display-name: Nginx HTTP server and a reverse proxy 1.22 (UBI 8)
-        openshift.io/provider-display-name: 'Red Hat, Inc.'
-        sampleRepo: 'https://github.com/sclorg/nginx-ex.git'
-        supports: nginx
-        tags: 'builder,nginx'
-        version: '1.22'
-      from:
-        kind: DockerImage
-        name: 'registry.redhat.io/ubi8/nginx-122:latest'
-      referencePolicy:
-        type: Local
-      name: 1.22-ubi8
-    - annotations:
-        description: >-
-          Build and serve static content via Nginx HTTP server and a reverse
-          proxy (nginx) on RHEL 8. For more information about using this builder
           image, including OpenShift considerations, see
           https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.
         iconClass: icon-nginx


### PR DESCRIPTION
The version 1.22 reached EOL in Nov 2025.

The current supported versions are based on:
https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle