### PR TITLE
Nodejs imagestream sync

### DIFF
--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is experimental, do not use it in production. Build and run NodeJS applications on UBI.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-nodejs-container/blob/master/24/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat NodeJS applications on UBI (experimental)
+apiVersion: v2
+appVersion: 0.0.7
+kubeVersion: '>=1.20.0'
+name: redhat-nodejs-imagestreams
+tags: builder,nodejs
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.7

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/Chart.yaml
@@ -5,10 +5,10 @@ description: |-
 annotations:
   charts.openshift.io/name: Red Hat NodeJS applications on UBI (experimental)
 apiVersion: v2
-appVersion: 0.0.7
+appVersion: 0.0.8
 kubeVersion: '>=1.20.0'
 name: redhat-nodejs-imagestreams
 tags: builder,nodejs
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.7
+version: 0.0.8

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/templates/nodejs-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/templates/nodejs-imagestream.yaml
@@ -1,0 +1,243 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: nodejs
+  annotations:
+    openshift.io/display-name: Node.js
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Node.js (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/24/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      supports: nodejs
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 24-ubi10
+    referencePolicy:
+      type: Local
+  - name: 24-ubi10
+    annotations:
+      openshift.io/display-name: Node.js 24 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 24 applications on UBI 10. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/24/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '24'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/nodejs-24:latest
+    referencePolicy:
+      type: Local
+  - name: 24-ubi10-minimal
+    annotations:
+      openshift.io/display-name: Node.js 24 (UBI 10 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 24 applications on UBI 10 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/24-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '24'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/nodejs-24-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 24-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 24 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 24 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/24/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '24'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-24:latest
+    referencePolicy:
+      type: Local
+  - name: 24-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 24 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 24 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/24-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '24'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-24-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 22-ubi10
+    annotations:
+      openshift.io/display-name: Node.js 22 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 22 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '22'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/nodejs-22:latest
+    referencePolicy:
+      type: Local
+  - name: 22-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 22 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 22 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '22'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-22:latest
+    referencePolicy:
+      type: Local
+  - name: 20-ubi9
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-20:latest
+    referencePolicy:
+      type: Local
+  - name: 20-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-20-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 22-ubi10-minimal
+    annotations:
+      openshift.io/display-name: Node.js 22 (UBI 10 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 22 applications on UBI 10 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '22'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/nodejs-22-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 22-ubi9-minimal
+    annotations:
+      openshift.io/display-name: Node.js 22 (UBI 9 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 22 applications on UBI 9 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '22'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/nodejs-22-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 22-ubi8
+    annotations:
+      openshift.io/display-name: Node.js 22 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 22 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '22'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-22:latest
+    referencePolicy:
+      type: Local
+  - name: 22-ubi8-minimal
+    annotations:
+      openshift.io/display-name: Node.js 22 (UBI 8 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 22 applications on UBI 8 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '22'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-22-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 20-ubi8
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-20:latest
+    referencePolicy:
+      type: Local
+  - name: 20-ubi8-minimal
+    annotations:
+      openshift.io/display-name: Node.js 20 (UBI 8 Minimal)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Node.js 20 applications on UBI 8 Minimal. For more
+        information about using this builder image, including OpenShift considerations,
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
+      iconClass: icon-nodejs
+      tags: builder,nodejs
+      version: '20'
+      sampleRepo: https://github.com/sclorg/nodejs-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/nodejs-20-minimal:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/templates/nodejs-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/templates/nodejs-imagestream.yaml
@@ -116,37 +116,6 @@ spec:
       name: registry.redhat.io/ubi9/nodejs-22:latest
     referencePolicy:
       type: Local
-  - name: 20-ubi9
-    annotations:
-      openshift.io/display-name: Node.js 20 (UBI 9)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 9. For more information
-        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
-      iconClass: icon-nodejs
-      tags: builder,nodejs
-      version: '20'
-      sampleRepo: https://github.com/sclorg/nodejs-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi9/nodejs-20:latest
-    referencePolicy:
-      type: Local
-  - name: 20-ubi9-minimal
-    annotations:
-      openshift.io/display-name: Node.js 20 (UBI 9 Minimal)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 9 Minimal. For more
-        information about using this builder image, including OpenShift considerations,
-        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
-      iconClass: icon-nodejs
-      tags: builder,nodejs
-      version: '20'
-      sampleRepo: https://github.com/sclorg/nodejs-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi9/nodejs-20-minimal:latest
-    referencePolicy:
-      type: Local
   - name: 22-ubi10-minimal
     annotations:
       openshift.io/display-name: Node.js 22 (UBI 10 Minimal)
@@ -210,34 +179,34 @@ spec:
       name: registry.redhat.io/ubi8/nodejs-22-minimal:latest
     referencePolicy:
       type: Local
-  - name: 20-ubi8
+  - name: 24-ubi8
     annotations:
-      openshift.io/display-name: Node.js 20 (UBI 8)
+      openshift.io/display-name: Node.js 24 (UBI 8)
       openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 8. For more information
-        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
+      description: Build and run Node.js 24 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/24/README.md.
       iconClass: icon-nodejs
       tags: builder,nodejs
-      version: '20'
+      version: '24'
       sampleRepo: https://github.com/sclorg/nodejs-ex.git
     from:
       kind: DockerImage
-      name: registry.redhat.io/ubi8/nodejs-20:latest
+      name: registry.redhat.io/ubi8/nodejs-24:latest
     referencePolicy:
       type: Local
-  - name: 20-ubi8-minimal
+  - name: 24-ubi8-minimal
     annotations:
-      openshift.io/display-name: Node.js 20 (UBI 8 Minimal)
+      openshift.io/display-name: Node.js 24 (UBI 8 Minimal)
       openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 8 Minimal. For more
+      description: Build and run Node.js 24 applications on UBI 8 Minimal. For more
         information about using this builder image, including OpenShift considerations,
-        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
+        see https://github.com/sclorg/s2i-nodejs-container/blob/master/24-minimal/README.md.
       iconClass: icon-nodejs
       tags: builder,nodejs
-      version: '20'
+      version: '24'
       sampleRepo: https://github.com/sclorg/nodejs-ex.git
     from:
       kind: DockerImage
-      name: registry.redhat.io/ubi8/nodejs-20-minimal:latest
+      name: registry.redhat.io/ubi8/nodejs-22-minimal:latest
     referencePolicy:
       type: Local

--- a/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-nodejs-imagestreams/0.0.8/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "nodejs-imagestream-test"
+      image: "registry.access.redhat.com/ubi8/nodejs-20"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          node -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never


### PR DESCRIPTION
Update currently support NodeJS versions based on the
https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle