### PR TITLE
Update python imagestreams

### DIFF
--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/Chart.yaml
@@ -1,0 +1,16 @@
+description: |-
+  This content is experimental, do not use it in production. Python imagestreams for using on OpenShift 4.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Python imagestreams (experimental).
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
+apiVersion: v2
+appVersion: 0.0.3
+kubeVersion: '>=1.20.0'
+name: redhat-python-imagestreams
+tags: builder,python
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.3

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/Chart.yaml
@@ -7,10 +7,10 @@ annotations:
   charts.openshift.io/provider: Red Hat
   charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.3
+appVersion: 0.0.4
 kubeVersion: '>=1.20.0'
 name: redhat-python-imagestreams
 tags: builder,python
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.3
+version: 0.0.4

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/templates/python-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/templates/python-imagestream.yaml
@@ -1,0 +1,170 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: python
+  annotations:
+    openshift.io/display-name: Python
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Python (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 3.12-ubi9
+    referencePolicy:
+      type: Local
+  - name: 3.12-minimal-ubi10
+    annotations:
+      openshift.io/display-name: Python 3.12 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.12 applications on UBI 10. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12-minimal/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.12,python
+      version: '3.12-minimal'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/python-312-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 3.12-minimal-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.12 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.12 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12-minimal/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.12,python
+      version: '3.12-minimal'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-312-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 3.12-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.12 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.12 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.12,python
+      version: '3.12'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-312:latest
+    referencePolicy:
+      type: Local
+  - name: 3.12-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.12 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.12 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.12,python
+      version: '3.12'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-312:latest
+    referencePolicy:
+      type: Local
+  - name: 3.11-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.11 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.11 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.11,python
+      version: '3.11'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-311:latest
+    referencePolicy:
+      type: Local
+  - name: 3.9-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.9 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.9 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.9,python
+      version: '3.9'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-39:latest
+    referencePolicy:
+      type: Local
+  - name: 3.11-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.11 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.11 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.11,python
+      version: '3.11'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-311:latest
+    referencePolicy:
+      type: Local
+  - name: 3.9-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.9 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.9 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.9,python
+      version: '3.9'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-39:latest
+    referencePolicy:
+      type: Local
+  - name: 3.6-ubi8
+    annotations:
+      openshift.io/display-name: Python 3.6 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.6 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.6,python
+      version: '3.6'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/python-36:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/templates/python-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/templates/python-imagestream.yaml
@@ -12,7 +12,7 @@ spec:
       openshift.io/display-name: Python (Latest)
       openshift.io/provider-display-name: Red Hat, Inc.
       description: |-
-        Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.
+        Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.14/README.md.
 
         WARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.
       iconClass: icon-python
@@ -21,7 +21,23 @@ spec:
       sampleRepo: https://github.com/sclorg/django-ex.git
     from:
       kind: ImageStreamTag
-      name: 3.12-ubi9
+      name: 3.14-minimal-ubi10
+    referencePolicy:
+      type: Local
+  - name: 3.14-minimal-ubi10
+    annotations:
+      openshift.io/display-name: Python 3.14 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.14 applications on UBI 10. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.14-minimal/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.14,python
+      version: '3.14-minimal'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/python-314-minimal:latest
     referencePolicy:
       type: Local
   - name: 3.12-minimal-ubi10
@@ -38,6 +54,38 @@ spec:
     from:
       kind: DockerImage
       name: registry.redhat.io/ubi10/python-312-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 3.14-minimal-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.14 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.14 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.14-minimal/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.14,python
+      version: '3.14-minimal'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-314-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 3.14-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.14 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.14 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.14/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.14,python
+      version: '3.14'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-314:latest
     referencePolicy:
       type: Local
   - name: 3.12-minimal-ubi9
@@ -134,22 +182,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.redhat.io/ubi8/python-311:latest
-    referencePolicy:
-      type: Local
-  - name: 3.9-ubi8
-    annotations:
-      openshift.io/display-name: Python 3.9 (UBI 8)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Python 3.9 applications on UBI 8. For more information
-        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.
-      iconClass: icon-python
-      tags: builder,python
-      supports: python:3.9,python
-      version: '3.9'
-      sampleRepo: https://github.com/sclorg/django-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi8/python-39:latest
     referencePolicy:
       type: Local
   - name: 3.6-ubi8

--- a/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-python-imagestreams/0.0.4/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "perl-imagestream-test"
+      image: "registry.access.redhat.com/ubi9/python-311"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          python -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never


### PR DESCRIPTION
Update the latest python imagestreams based on the 

https://access.redhat.com/support/policy/updates/rhel8-app-streams-life-cycle