### PR TITLE
Update redis imagestreams

### DIFF
--- a/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  This content is expermental, do not use it in production. Provides a Redis database on RHEL imagestreams.
+  For more information about Redis container see https://github.com/sclorg/redis-container/.
+annotations:
+  charts.openshift.io/name: Provides a Redis database on RHEL imagestreams (experimental).
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: redis-imagestreams
+tags: builder,redis
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/Chart.yaml
@@ -1,13 +1,15 @@
 description: |-
-  This content is expermental, do not use it in production. Provides a Redis database on RHEL imagestreams.
+  This content is experimental, do not use it in production. Provides a Redis database on RHEL imagestreams.
   For more information about Redis container see https://github.com/sclorg/redis-container/.
 annotations:
-  charts.openshift.io/name: Provides a Redis database on RHEL imagestreams (experimental).
+  charts.openshift.io/name: Provides a Redis database on RHEL imagestreams (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.1
+appVersion: 0.0.2
 kubeVersion: '>=1.20.0'
-name: redis-imagestreams
+name: redhat-redis-imagestreams
 tags: builder,redis
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.1
+version: 0.0.2

--- a/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/templates/imagestreams.yaml
@@ -1,0 +1,76 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Redis
+  name: redis
+spec:
+  tags:
+    - annotations:
+        description: >-
+          Provides a Redis database on RHEL. For more information about using
+          this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of Redis available on OpenShift,
+          including major version updates.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+      from:
+        kind: ImageStreamTag
+        name: 6-el8
+      referencePolicy:
+        type: Local
+      name: latest
+    - annotations:
+        description: >-
+          Provides a Redis 6 database on RHEL 9. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis 6 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+        version: '6'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/redis-6:latest'
+      referencePolicy:
+        type: Local
+      name: 6-el9
+    - annotations:
+        description: >-
+          Provides a Redis 6 database on RHEL 8. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis 6 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+        version: '6'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel8/redis-6:latest'
+      referencePolicy:
+        type: Local
+      name: 6-el8
+    - annotations:
+        description: >-
+          Provides a Redis 6 database on RHEL 7. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis 6 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+        version: '6'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhscl/redis-6-rhel7:latest'
+      referencePolicy:
+        type: Local
+      name: 6-el7

--- a/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat/redhat-redis-imagestreams/0.0.2/src/templates/imagestreams.yaml
@@ -10,7 +10,7 @@ spec:
         description: >-
           Provides a Redis database on RHEL. For more information about using
           this database image, including OpenShift considerations, see
-          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+          https://github.com/sclorg/redis-container/tree/master/7/README.md.
 
 
           WARNING: By selecting this tag, your application will automatically
@@ -22,7 +22,7 @@ spec:
         tags: redis
       from:
         kind: ImageStreamTag
-        name: 6-el8
+        name: 7-el9
       referencePolicy:
         type: Local
       name: latest
@@ -44,6 +44,22 @@ spec:
       name: 6-el9
     - annotations:
         description: >-
+          Provides a Redis 7 database on RHEL 9. For more information about
+          using this database image, including OpenShift considerations, see
+          https://github.com/sclorg/redis-container/tree/master/7/README.md.
+        iconClass: icon-redis
+        openshift.io/display-name: Redis 7 (RHEL 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        tags: redis
+        version: '7'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/rhel9/redis-7:latest'
+      referencePolicy:
+        type: Local
+      name: 7-el9
+    - annotations:
+        description: >-
           Provides a Redis 6 database on RHEL 8. For more information about
           using this database image, including OpenShift considerations, see
           https://github.com/sclorg/redis-container/tree/master/6/README.md.
@@ -58,19 +74,3 @@ spec:
       referencePolicy:
         type: Local
       name: 6-el8
-    - annotations:
-        description: >-
-          Provides a Redis 6 database on RHEL 7. For more information about
-          using this database image, including OpenShift considerations, see
-          https://github.com/sclorg/redis-container/tree/master/6/README.md.
-        iconClass: icon-redis
-        openshift.io/display-name: Redis 6 (RHEL 7)
-        openshift.io/provider-display-name: 'Red Hat, Inc.'
-        tags: redis
-        version: '6'
-      from:
-        kind: DockerImage
-        name: 'registry.redhat.io/rhscl/redis-6-rhel7:latest'
-      referencePolicy:
-        type: Local
-      name: 6-el7


### PR DESCRIPTION
Update redis-imagestreams in helm charts
Fix registry sources
The latest imagestream is 7.

Remove RHEL7 streams. It reached EOL
