### PR TITLE
Update ruby imagestreams

### DIFF
--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/Chart.yaml
@@ -1,0 +1,14 @@
+description: |-
+  This content is expermental, do not use it in production. Ruby imagestreams on UBI.
+  For more information about using this builder image, including OpenShift considerations,
+  see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+annotations:
+  charts.openshift.io/name: Red Hat Ruby applications on UBI (experimental)
+apiVersion: v2
+appVersion: 0.0.5
+kubeVersion: '>=1.20.0'
+name: redhat-ruby-imagestreams
+tags: builder,ruby
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.5

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/Chart.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/Chart.yaml
@@ -1,14 +1,14 @@
 description: |-
-  This content is expermental, do not use it in production. Ruby imagestreams on UBI.
+  This content is experimental, do not use it in production. Ruby imagestreams on UBI.
   For more information about using this builder image, including OpenShift considerations,
-  see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+  see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.
 annotations:
   charts.openshift.io/name: Red Hat Ruby applications on UBI (experimental)
 apiVersion: v2
-appVersion: 0.0.5
+appVersion: 0.0.6
 kubeVersion: '>=1.20.0'
 name: redhat-ruby-imagestreams
 tags: builder,ruby
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.5
+version: 0.0.6

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/templates/ruby-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/templates/ruby-imagestream.yaml
@@ -1,0 +1,106 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: ruby
+  annotations:
+    openshift.io/display-name: Ruby
+spec:
+  tags:
+  - name: latest
+    annotations:
+      openshift.io/display-name: Ruby (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: |-
+        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.3/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: ImageStreamTag
+      name: 3.3-ubi9
+    referencePolicy:
+      type: Local
+  - name: 3.3-ubi10
+    annotations:
+      openshift.io/display-name: Ruby 3.3 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.3 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.3,ruby
+      version: '3.3'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/ruby-33:latest
+    referencePolicy:
+      type: Local
+  - name: 3.3-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 3.3 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.3 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.3,ruby
+      version: '3.3'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-33:latest
+    referencePolicy:
+      type: Local
+  - name: 3.3-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 3.3 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.3 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.3,ruby
+      version: '3.3'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-33:latest
+    referencePolicy:
+      type: Local
+  - name: 3.0-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 3.0 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 3.0 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:3.0,ruby
+      version: '3.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-30:latest
+    referencePolicy:
+      type: Local
+  - name: 2.5-ubi8
+    annotations:
+      openshift.io/display-name: Ruby 2.5 (UBI 8)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 2.5 applications on UBI 8. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:2.5,ruby
+      version: '2.5'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi8/ruby-25:latest
+    referencePolicy:
+      type: Local

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/templates/ruby-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/templates/ruby-imagestream.yaml
@@ -12,7 +12,7 @@ spec:
       openshift.io/display-name: Ruby (Latest)
       openshift.io/provider-display-name: Red Hat, Inc.
       description: |-
-        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.3/README.md.
+        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/4.0/README.md.
 
         WARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.
       iconClass: icon-ruby
@@ -21,7 +21,39 @@ spec:
       sampleRepo: https://github.com/sclorg/ruby-ex.git
     from:
       kind: ImageStreamTag
-      name: 3.3-ubi9
+      name: 4.0-ubi10
+    referencePolicy:
+      type: Local
+  - name: 4.0-ubi10
+    annotations:
+      openshift.io/display-name: Ruby 4.0 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 4.0 applications on UBI 10. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:4.0,ruby
+      version: '4.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/ruby-40:latest
+    referencePolicy:
+      type: Local
+  - name: 4.0-ubi9
+    annotations:
+      openshift.io/display-name: Ruby 4.0 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Ruby 4.0 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.
+      iconClass: icon-ruby
+      tags: builder,ruby
+      supports: ruby:4.0,ruby
+      version: '4.0'
+      sampleRepo: https://github.com/sclorg/ruby-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/ruby-40:latest
     referencePolicy:
       type: Local
   - name: 3.3-ubi10

--- a/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/templates/tests/test-import-imagestream.yaml
+++ b/charts/redhat/redhat/redhat-ruby-imagestreams/0.0.6/src/templates/tests/test-import-imagestream.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-connection-test"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: "ruby-imagestream-test"
+      image: "registry.access.redhat.com/ubi9/ruby-31"
+      imagePullPolicy: IfNotPresent
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          ruby -v
+  lookupPolicy:
+    local: true
+  restartPolicy: Never


### PR DESCRIPTION
Update imagestreams.

Added new version 4.0 and deprecated versions that reached EOL
