### PR TITLE
axera 1.2.0

### DIFF
--- a/charts/partners/axera/axera/1.2.0/report.yaml
+++ b/charts/partners/axera/axera/1.2.0/report.yaml
@@ -1,0 +1,116 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.15.0
+        profile:
+            VendorType: partner
+            version: v1.3
+        reportDigest: uint64:16030615983648528673
+        chart-uri: N/A
+        digests:
+            chart: sha256:6ee76345d95d64a104dbe07eefc2e5cf9828e87798ab45ad9935543fdd21e9b7
+            package: a5b9846e2ea39a8443afacd830e3969a444111c428aca1ae9980e225c668b9cf
+        lastCertifiedTimestamp: "2026-06-19T19:34:58.179556+00:00"
+        testedOpenShiftVersion: "4.20"
+        supportedOpenShiftVersions: '>=4.12'
+        webCatalogOnly: true
+    chart:
+        name: axera
+        home: https://axerasecurity.com
+        sources:
+            - https://github.com/AxeraSecurity
+        version: 1.2.0
+        description: Axera — Kubernetes microsegmentation and network detection & response (NDR) for OpenShift. Maps every east-west and egress flow, turns observed traffic into least-privilege NetworkPolicy, and triages incidents with on-prem AI. Runs entirely in-cluster; CNI-agnostic; strictly additive (observes first, enforces nothing until you choose). Supports all-internal (one-box) or external Postgres + Kafka + AI endpoints.
+        keywords:
+            - microsegmentation
+            - network-detection-and-response
+            - ndr
+            - kubernetes-network-policy
+            - zero-trust
+            - security
+            - openshift
+        maintainers:
+            - name: Axera Security
+              email: support@axerasecurity.com
+              url: https://axerasecurity.com
+        icon: https://axerasecurity.com/og.png
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: 7.0.0
+        deprecated: false
+        annotations:
+            charts.openshift.io/archs: amd64
+            charts.openshift.io/name: Axera Microsegmentation & NDR
+            charts.openshift.io/provider: Axera Security
+            charts.openshift.io/supportURL: https://axerasecurity.com/support
+        kubeversion: '>=1.25.0-0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : quay.io/axera/microsegmentation-frontend:v7.0.0
+        Image is Red Hat certified : registry.access.redhat.com/ubi9/ubi-minimal:latest
+        Image certification skipped : registry.redhat.io/rhel9/postgresql-16:latest
+        Image is Red Hat certified : quay.io/axera/microsegmentation-api:v7.0.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-proxy:v7.0.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-allowdropmonitor:v7.0.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-radar:v7.0.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-networkpolicywatcher:v7.0.0
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist


### PR DESCRIPTION
Certification report for the Axera Helm chart, distributed via external repository (web catalog).

- Chart: axera 1.2.0 (vendor: axera / QUASYS)
- Hosted at: https://axerasecurity.github.io/helm-charts
- chart-verifier: all checks pass — chart-testing on OpenShift 4.20, images-are-certified (all 6 component images Red Hat certified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)