### PR TITLE
Set providerDelivery: true for axera

### DIFF
--- a/charts/partners/axera/axera/OWNERS
+++ b/charts/partners/axera/axera/OWNERS
@@ -2,7 +2,7 @@ chart:
   name: axera
   shortDescription: "Kubernetes microsegmentation & NDR for OpenShift \u2014 least-privilege\
     \ NetworkPolicy from observed traffic, with on-prem AI incident triage."
-providerDelivery: false
+providerDelivery: true
 publicPgpKey: unknown
 users:
 - githubUsername: AltugYildirim


### PR DESCRIPTION
Align the axera OWNERS with the chart's external (web-catalog) distribution method configured in Red Hat Partner Connect. The chart is hosted at https://axerasecurity.github.io/helm-charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)