### PR TITLE
axera 1.3.0

### DIFF
--- a/charts/partners/axera/axera/1.3.0/report.yaml
+++ b/charts/partners/axera/axera/1.3.0/report.yaml
@@ -1,0 +1,116 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.15.0
+        profile:
+            VendorType: partner
+            version: v1.3
+        reportDigest: uint64:12664009795354987373
+        chart-uri: N/A
+        digests:
+            chart: sha256:181fd5b8dee2e262403b9a556142d83541a44ee814ac4de5bd69f61f5dcb6568
+            package: 998e527a85129a9f081e2c0399d76b3dcdc1f4b0c6580085ed9f9d0f2bf6cbed
+        lastCertifiedTimestamp: "2026-07-01T22:40:46.50194+00:00"
+        testedOpenShiftVersion: "4.20"
+        supportedOpenShiftVersions: '>=4.12'
+        webCatalogOnly: true
+    chart:
+        name: axera
+        home: https://axerasecurity.com
+        sources:
+            - https://github.com/AxeraSecurity
+        version: 1.3.0
+        description: Axera — Kubernetes microsegmentation and network detection & response (NDR) for OpenShift. Maps every east-west and egress flow, turns observed traffic into least-privilege NetworkPolicy, and triages incidents with on-prem AI. Runs entirely in-cluster; CNI-agnostic; strictly additive (observes first, enforces nothing until you choose). Supports all-internal (one-box) or external Postgres + Kafka + AI endpoints.
+        keywords:
+            - microsegmentation
+            - network-detection-and-response
+            - ndr
+            - kubernetes-network-policy
+            - zero-trust
+            - security
+            - openshift
+        maintainers:
+            - name: Axera Security
+              email: support@axerasecurity.com
+              url: https://axerasecurity.com
+        icon: https://axerasecurity.github.io/helm-charts/axera-logo.svg
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: 8.1.0
+        deprecated: false
+        annotations:
+            charts.openshift.io/archs: amd64
+            charts.openshift.io/name: Axera Microsegmentation & NDR
+            charts.openshift.io/provider: Axera Security
+            charts.openshift.io/supportURL: https://axerasecurity.com/support
+        kubeversion: '>=1.25.0-0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image certification skipped : registry.redhat.io/rhel9/postgresql-16:latest
+        Image is Red Hat certified : quay.io/axera/microsegmentation-api:v8.1.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-proxy:v8.1.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-allowdropmonitor:v8.1.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-radar:v8.1.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-networkpolicywatcher:v8.1.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-frontend:v8.1.0
+        Image is Red Hat certified : registry.access.redhat.com/ubi9/ubi-minimal:latest
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified


### PR DESCRIPTION
Provider-delivered (web-catalog-only) chart-verifier report for **axera 1.3.0** (appVersion 8.1.0).

- All 6 operand images `microsegmentation-*:v8.1.0` are Red Hat container-certified → `images-are-certified` PASS
- `chart-testing` PASS on OpenShift 4.20
- Adds the `ProtectedNamespaceSettings` schema migration

13 checks PASS, 1 SKIP (signature). Chart hosted at https://axerasecurity.github.io/helm-charts/axera-1.3.0.tgz