### PR TITLE
axera 1.4.0

### DIFF
--- a/charts/partners/axera/axera/1.4.0/report.yaml
+++ b/charts/partners/axera/axera/1.4.0/report.yaml
@@ -1,0 +1,117 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.15.0
+        profile:
+            VendorType: partner
+            version: v1.3
+        reportDigest: uint64:11391078179443203592
+        chart-uri: N/A
+        digests:
+            chart: sha256:6f418ca807cc4475dc4b402c59513c1a1c3d3e38a4f9ace07c66fabdc5c703ba
+            package: da7b0b9de4030267ef8f3dabc143476e74d5ba24a1d36a9fd799fafc31d16f45
+        lastCertifiedTimestamp: "2026-07-03T20:24:19.967272+00:00"
+        testedOpenShiftVersion: "4.20"
+        supportedOpenShiftVersions: '>=4.12'
+        webCatalogOnly: true
+    chart:
+        name: axera
+        home: https://axerasecurity.com
+        sources:
+            - https://github.com/AxeraSecurity
+        version: 1.4.0
+        description: Axera — Kubernetes microsegmentation and network detection & response (NDR) for OpenShift. Maps every east-west and egress flow, turns observed traffic into least-privilege NetworkPolicy, and triages incidents with on-prem AI. Runs entirely in-cluster; CNI-agnostic; strictly additive (observes first, enforces nothing until you choose). Supports all-internal (one-box) or external Postgres + Kafka + AI endpoints.
+        keywords:
+            - microsegmentation
+            - network-detection-and-response
+            - ndr
+            - kubernetes-network-policy
+            - zero-trust
+            - security
+            - openshift
+        maintainers:
+            - name: Axera Security
+              email: support@axerasecurity.com
+              url: https://axerasecurity.com
+        icon: https://axerasecurity.github.io/helm-charts/axera-logo.svg
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: 8.3.0
+        deprecated: false
+        annotations:
+            charts.openshift.io/archs: amd64
+            charts.openshift.io/name: Axera Microsegmentation & NDR
+            charts.openshift.io/provider: Axera Security
+            charts.openshift.io/supportURL: https://axerasecurity.com/support
+        kubeversion: '>=1.25.0-0'
+        dependencies: []
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/has-notes
+      type: Optional
+      outcome: PASS
+      reason: Chart does contain NOTES.txt
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : quay.io/axera/microsegmentation-allowdropmonitor:v8.3.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-radar:v8.3.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-networkpolicywatcher:v8.3.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-frontend:v8.3.0
+        Image certification skipped : registry.redhat.io/rhel9/postgresql-16:latest
+        Image is Red Hat certified : registry.access.redhat.com/ubi9/ubi-minimal:latest
+        Image is Red Hat certified : quay.io/axera/microsegmentation-api:v8.3.0
+        Image is Red Hat certified : quay.io/axera/microsegmentation-proxy:v8.3.0
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+


### PR DESCRIPTION
Provider-delivered (web-catalog-only) report submission for **axera** chart **1.4.0** (appVersion 8.3.0).

- Report-only; chart is hosted by the partner at https://axerasecurity.github.io/helm-charts
- chart-verifier 1.15.0, partner profile v1.3
- All mandatory checks **PASS** (13 PASS, signature SKIPPED/optional); `chart-testing` passed on OpenShift 4.20
- All six Axera images (v8.3.0) are Red Hat certified

What's new in 1.4.0: storage-less DB-backed DataProtection key ring option (`app.dpKeysStore`), v8.3.0 images, OpenShift-safe helm test hook.