### PR TITLE
Community chart: add n8n 1.17.1 verify report

### DIFF
--- a/charts/community/mpizarro/n8n/1.17.1/report.yaml
+++ b/charts/community/mpizarro/n8n/1.17.1/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: community
             version: v1.1
-        reportDigest: uint64:10926778683208670123
+        reportDigest: uint64:8252478978570974632
         chart-uri: https://maximilianopizarro.github.io/n8n-helm-chart/n8n-1.17.1.tgz
         digests:
             chart: sha256:43c8e572a5402c1fb36be1bc412653581da267b7a7055db07c34c2d1d9adf30a
             package: 6cd35d6d5e51f9549b39dc7a7c62cc78b141ec466d6e92a00b3a24f5681c41fa
-        lastCertifiedTimestamp: "2026-08-01T16:28:52.817624+00:00"
-        testedOpenShiftVersion: N/A
+        lastCertifiedTimestamp: "2026-08-01T17:42:58.224136+00:00"
+        testedOpenShiftVersion: "4.22"
         supportedOpenShiftVersions: '>=4.7'
         webCatalogOnly: false
     chart:
@@ -123,42 +123,34 @@ metadata:
         type: application
     chart-overrides: ""
 results:
-    - check: v1.0/contains-values
-      type: Optional
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/is-helm-v3
-      type: Optional
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contain-csi-objects
-      type: Optional
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
-      type: Optional
-      outcome: PASS
-      reason: All required annotations present
     - check: v1.0/not-contains-crds
       type: Optional
       outcome: PASS
       reason: Chart does not contain CRDs
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
     - check: v1.0/contains-test
       type: Optional
       outcome: PASS
       reason: Chart test files exist
-    - check: v1.0/has-readme
+    - check: v1.0/contains-values
       type: Optional
       outcome: PASS
-      reason: Chart has a README
+      reason: Values file exist
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
     - check: v1.0/contains-values-schema
       type: Optional
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.1/has-kubeversion
+    - check: v1.0/has-readme
       type: Optional
       outcome: PASS
-      reason: Kubernetes version specified
+      reason: Chart has a README
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
@@ -167,12 +159,20 @@ results:
       type: Optional
       outcome: FAIL
       reason: |-
-        Image is not Red Hat certified : n8nio/n8n:2.32.7 : repository not found: n8nio/n8n
-        Image is not Red Hat certified : n8nio/n8n:2.32.7
+        Image is not Red Hat certified : axllent/mailpit:latest : repository not found: axllent/mailpit
+        Image is not Red Hat certified : axllent/mailpit:latest
+        Failed to certify images : quay.io/maximilianopizarro/n8n:2.32.7 : No images found for Registry/Repository: quay.io/maximilianopizarro/n8n
         Image is not Red Hat certified : alpine : repository not found: alpine
         Image is not Red Hat certified : alpine
+    - check: v1.0/not-contain-csi-objects
+      type: Optional
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.0/chart-testing
       type: Optional
-      outcome: FAIL
-      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
-
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified

--- a/charts/community/mpizarro/n8n/1.17.1/report.yaml
+++ b/charts/community/mpizarro/n8n/1.17.1/report.yaml
@@ -1,0 +1,178 @@
+apiversion: v1
+kind: verify-report
+metadata:
+    tool:
+        verifier-version: 1.16.0
+        profile:
+            VendorType: community
+            version: v1.1
+        reportDigest: uint64:10926778683208670123
+        chart-uri: https://maximilianopizarro.github.io/n8n-helm-chart/n8n-1.17.1.tgz
+        digests:
+            chart: sha256:43c8e572a5402c1fb36be1bc412653581da267b7a7055db07c34c2d1d9adf30a
+            package: 6cd35d6d5e51f9549b39dc7a7c62cc78b141ec466d6e92a00b3a24f5681c41fa
+        lastCertifiedTimestamp: "2026-08-01T16:28:52.817624+00:00"
+        testedOpenShiftVersion: N/A
+        supportedOpenShiftVersions: '>=4.7'
+        webCatalogOnly: false
+    chart:
+        name: n8n
+        home: https://maximilianopizarro.github.io/n8n-helm-chart/
+        sources:
+            - https://github.com/maximilianoPizarro/n8n-helm-chart
+            - https://github.com/n8n-io/n8n
+            - https://n8n.io/
+            - https://github.com/maximilianoPizarro/openshift-mcp-server
+        version: 1.17.1
+        description: Helm Chart for deploying n8n on Kubernetes and Red Hat OpenShift, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services. Includes optional Mailpit for email testing and OpenShift Developer Sandbox support.
+        keywords:
+            - Workflow Automation
+            - Workflow
+            - iPaaS
+            - integration-framework
+            - low-code-plattform
+            - low-code
+            - openshift
+            - mcp-server
+            - ai-workflows
+        maintainers:
+            - name: maximilianoPizarro
+              email: maximiliano.pizarro.5@gmail.com
+              url: https://github.com/maximilianoPizarro
+            - name: pkstaz
+              email: cestay@redhat.com
+              url: https://github.com/n8n-io
+        icon: https://avatars1.githubusercontent.com/u/45487711?s=200&v=4
+        apiversion: v2
+        condition: ""
+        tags: ""
+        appversion: 2.32.7
+        deprecated: false
+        annotations:
+            artifacthub.io/changes: |
+                - kind: fixed
+                  description: "Align values.schema.json with worker.enabled, webhook.enabled, and main.persistence.type for catalog validation"
+                - kind: fixed
+                  description: "Fix dynamic PVC wiring (persistence.type + accessMode) and wire startupProbe on main/worker/webhook"
+                - kind: changed
+                  description: "Tune main probes for OpenShift cold starts (startupProbe + longer liveness/readiness timeouts)"
+                - kind: changed
+                  description: "Update n8n app version from 1.123.28 to 2.32.7 (latest stable). Chart 1.16.0 remains available for existing catalog RC installs"
+                - kind: fixed
+                  description: "Fix EACCES permission denied mkdir '/.n8n' on OpenShift by always injecting HOME and N8N_USER_FOLDER from main.persistence.mountPath"
+                - kind: changed
+                  description: "Document OpenShift Developer Sandbox install path and n8n 1.x to 2.x migration notes"
+                - kind: added
+                  description: "Add 7 MCP Server workflows with real JSON-RPC tool calls + AI analysis via LiteLLM/Granite + Mailpit email reports"
+                - kind: added
+                  description: "Add workflow auto-import via Deployment initContainers (download + n8n import:workflow)"
+                - kind: added
+                  description: "Add Mailpit as optional SMTP test service with OpenShift Route support"
+                - kind: added
+                  description: "Add enableServiceLinks for Developer Sandbox N8N_PORT env conflict resolution"
+                - kind: added
+                  description: "Add route.sccRoleDisabled for Developer Sandbox RBAC compatibility"
+                - kind: added
+                  description: "Add Red Hat UBI container image at quay.io/maximilianopizarro/n8n via GitHub Actions CI"
+                - kind: added
+                  description: "Add Chart Verifier GitHub Actions workflow for Red Hat Community certification"
+                - kind: added
+                  description: "Add configurable volume mount path (main.persistence.mountPath) for restricted environments"
+                - kind: added
+                  description: "Add image.variant option (official/ubi) for selecting between Alpine wget and UBI curl in workflow auto-import initContainers"
+                - kind: added
+                  description: "Add AI Format & Explain pipeline step to all 7 MCP workflows via LiteLLM/Granite with health assessments"
+                - kind: changed
+                  description: "Redesign GitHub Pages documentation with MCP pipeline architecture, lightbox viewer, and Mermaid diagrams"
+                - kind: fixed
+                  description: "Fix ClusterIP_ typo in service template"
+                - kind: fixed
+                  description: "Fix hardcoded names in role.yaml to use chart naming helpers (supports n8n-dev-east style release names)"
+            artifacthub.io/links: |
+                - name: Documentation
+                  url: https://maximilianopizarro.github.io/n8n-helm-chart/
+                - name: OpenShift MCP Server
+                  url: https://maximilianopizarro.github.io/openshift-mcp-server
+                - name: OpenShift MCP Server (Artifact Hub)
+                  url: https://artifacthub.io/packages/helm/openshift-mcp-server/openshift-mcp-server
+                - name: n8n Sandbox Workflows
+                  url: https://github.com/maximilianoPizarro/n8n-sandbox
+            artifacthub.io/prerelease: "false"
+            artifacthub.io/recommendations: |
+                - url: https://artifacthub.io/packages/helm/openshift-mcp-server/openshift-mcp-server
+            artifacthub.io/screenshots: |
+                - title: Mailpit Inbox - Workflow Email Reports
+                  url: https://raw.githubusercontent.com/maximilianoPizarro/n8n-helm-chart/main/docs/screenshots/mailpit-inbox.png
+                - title: Pod Status Report - Red Hat Branded HTML Email
+                  url: https://raw.githubusercontent.com/maximilianoPizarro/n8n-helm-chart/main/docs/screenshots/mailpit-email-detail.png
+                - title: MCP Inspector - monitorDeployments Verification
+                  url: https://raw.githubusercontent.com/maximilianoPizarro/n8n-helm-chart/main/docs/screenshots/mcp-inspector-monitor-deployments.png
+                - title: n8n All Workflows List
+                  url: https://raw.githubusercontent.com/maximilianoPizarro/n8n-helm-chart/main/docs/screenshots/n8n-all-workflows-list.png
+                - title: n8n Dashboard
+                  url: https://raw.githubusercontent.com/maximilianoPizarro/n8n-helm-chart/main/docs/screenshots/n8n-dashboard.png
+                - title: n8n via Podman - Red Hat UBI 9 Container
+                  url: https://raw.githubusercontent.com/maximilianoPizarro/n8n-helm-chart/main/docs/screenshots/n8n-podman-welcome.png
+            charts.openshift.io/name: n8n
+        kubeversion: '>=1.20.0'
+        dependencies:
+            - name: valkey
+              version: 2.4.7
+              repository: oci://registry-1.docker.io/bitnamicharts
+              condition: valkey.enabled
+        type: application
+    chart-overrides: ""
+results:
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contain-csi-objects
+      type: Optional
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/contains-values-schema
+      type: Optional
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/images-are-certified
+      type: Optional
+      outcome: FAIL
+      reason: |-
+        Image is not Red Hat certified : n8nio/n8n:2.32.7 : repository not found: n8nio/n8n
+        Image is not Red Hat certified : n8nio/n8n:2.32.7
+        Image is not Red Hat certified : alpine : repository not found: alpine
+        Image is not Red Hat certified : alpine
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: FAIL
+      reason: 'invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable'
+


### PR DESCRIPTION
## Summary
- Add chart-verifier report for community chart **n8n 1.17.1** (`appVersion` 2.32.7)
- Chart URL: https://maximilianopizarro.github.io/n8n-helm-chart/n8n-1.17.1.tgz
- Vendor: `mpizarro` / chart: `n8n`
- Profile: community v1.1

## Notes
- Mandatory checks (`helm-lint`, `contains-values-schema`, etc.) PASS
- Optional fails expected for community images (`n8nio/n8n`, `alpine` not RH certified) and chart-testing without cluster in CI
- Validated on OpenShift (ROSA): deploy with `values-sandbox.yaml`, 0 restarts, healthz ok, 7 workflows imported

## Test plan
- [ ] Catalog CI verifies OWNERS + report for `charts/community/mpizarro/n8n/1.17.1`